### PR TITLE
feat: #47 예약, 카테고리/옵션/그룹 관리 및 예약 연동 기능 구현

### DIFF
--- a/m-common/src/main/java/com/antmen/antwork/common/api/CategoryController.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/CategoryController.java
@@ -1,0 +1,101 @@
+package com.antmen.antwork.common.api;
+
+import com.antmen.antwork.common.api.request.CategoryRequestDto;
+import com.antmen.antwork.common.api.response.CategoryResponseDto;
+import com.antmen.antwork.common.domain.entity.Category;
+import com.antmen.antwork.common.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/category")
+@RequiredArgsConstructor
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public ResponseEntity<List<CategoryResponseDto>> getAllCategories() {
+        List<Category> categories = categoryService.getAllCategories();
+        List<CategoryResponseDto> result = categories.stream()
+                .map(c -> CategoryResponseDto.builder()
+                        .categoryId(c.getCategoryId())
+                        .categoryName(c.getCategoryName())
+                        .categoryPrice(c.getCategoryPrice())
+                        .categoryTime(c.getCategoryTime())
+                        .build())
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CategoryResponseDto> getCategory(@PathVariable Long id) {
+        try {
+            Category c = categoryService.getCategory(id);
+            CategoryResponseDto dto = CategoryResponseDto.builder()
+                    .categoryId(c.getCategoryId())
+                    .categoryName(c.getCategoryName())
+                    .categoryPrice(c.getCategoryPrice())
+                    .categoryTime(c.getCategoryTime())
+                    .build();
+            return ResponseEntity.ok(dto);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<CategoryResponseDto> createCategory(@RequestBody CategoryRequestDto dto) {
+        try {
+            Category category = Category.builder()
+                    .categoryName(dto.getCategoryName())
+                    .categoryPrice(dto.getCategoryPrice())
+                    .categoryTime(dto.getCategoryTime())
+                    .build();
+            Category saved = categoryService.createCategory(category);
+            CategoryResponseDto response = CategoryResponseDto.builder()
+                    .categoryId(saved.getCategoryId())
+                    .categoryName(saved.getCategoryName())
+                    .categoryPrice(saved.getCategoryPrice())
+                    .categoryTime(saved.getCategoryTime())
+                    .build();
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<CategoryResponseDto> updateCategory(@PathVariable Long id, @RequestBody CategoryRequestDto dto) {
+        try {
+            Category update = Category.builder()
+                    .categoryName(dto.getCategoryName())
+                    .categoryPrice(dto.getCategoryPrice())
+                    .categoryTime(dto.getCategoryTime())
+                    .build();
+            Category saved = categoryService.updateCategory(id, update);
+            CategoryResponseDto response = CategoryResponseDto.builder()
+                    .categoryId(saved.getCategoryId())
+                    .categoryName(saved.getCategoryName())
+                    .categoryPrice(saved.getCategoryPrice())
+                    .categoryTime(saved.getCategoryTime())
+                    .build();
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
+        try {
+            categoryService.deleteCategory(id);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/api/CategoryGroupController.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/CategoryGroupController.java
@@ -1,0 +1,44 @@
+package com.antmen.antwork.common.api;
+
+import com.antmen.antwork.common.service.CategoryGroupService;
+import com.antmen.antwork.common.domain.entity.CategoryGroup;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/category-group")
+@RequiredArgsConstructor
+public class CategoryGroupController {
+    private final CategoryGroupService categoryGroupService;
+
+    // 예약별 카테고리 연결 생성 (여러 카테고리 연결)
+    @PostMapping("/reservation/{reservationId}")
+    public ResponseEntity<Void> saveCategoryGroups(
+            @PathVariable Long reservationId,
+            @RequestBody List<Long> categoryIdList) {
+        try {
+            categoryGroupService.saveCategoryGroups(reservationId, categoryIdList);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    // 예약ID로 연결된 카테고리ID 리스트 조회
+    @GetMapping("/reservation/{reservationId}")
+    public ResponseEntity<List<Long>> getCategoryIdsByReservationId(@PathVariable Long reservationId) {
+        try {
+            List<CategoryGroup> groups = categoryGroupService.getCategoryGroupsByReservationId(reservationId);
+            List<Long> categoryIds = groups.stream()
+                    .map(CategoryGroup::getCategoryId)
+                    .collect(Collectors.toList());
+            return ResponseEntity.ok(categoryIds);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/api/CategoryOptionController.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/CategoryOptionController.java
@@ -1,0 +1,113 @@
+package com.antmen.antwork.common.api;
+
+import com.antmen.antwork.common.api.request.CategoryOptionRequestDto;
+import com.antmen.antwork.common.api.response.CategoryOptionResponseDto;
+import com.antmen.antwork.common.domain.entity.CategoryOption;
+import com.antmen.antwork.common.service.CategoryOptionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/category-option")
+@RequiredArgsConstructor
+public class CategoryOptionController {
+    private final CategoryOptionService categoryOptionService;
+
+    // 카테고리별 옵션 리스트 조회
+    @GetMapping("/category/{categoryId}")
+    public ResponseEntity<List<CategoryOptionResponseDto>> getOptionsByCategory(@PathVariable Long categoryId) {
+        List<CategoryOption> options = categoryOptionService.getOptionsByCategoryId(categoryId);
+        List<CategoryOptionResponseDto> result = options.stream()
+                .map(o -> CategoryOptionResponseDto.builder()
+                        .coId(o.getCoId())
+                        .coName(o.getCoName())
+                        .coPrice(o.getCoPrice())
+                        .coTime(o.getCoTime())
+                        .build())
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(result);
+    }
+
+    // 옵션 전체 조회 (관리자)
+    @GetMapping
+    public ResponseEntity<List<CategoryOptionResponseDto>> getAllOptions() {
+        List<CategoryOption> options = categoryOptionService.getAllOptions();
+        List<CategoryOptionResponseDto> result = options.stream()
+                .map(o -> CategoryOptionResponseDto.builder()
+                        .coId(o.getCoId())
+                        .coName(o.getCoName())
+                        .coPrice(o.getCoPrice())
+                        .coTime(o.getCoTime())
+                        .build())
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(result);
+    }
+
+    // 옵션 단건 조회 (관리자)
+    @GetMapping("/{coId}")
+    public ResponseEntity<CategoryOptionResponseDto> getOption(@PathVariable Long coId) {
+        try {
+            CategoryOption o = categoryOptionService.getOption(coId);
+            CategoryOptionResponseDto dto = CategoryOptionResponseDto.builder()
+                    .coId(o.getCoId())
+                    .coName(o.getCoName())
+                    .coPrice(o.getCoPrice())
+                    .coTime(o.getCoTime())
+                    .build();
+            return ResponseEntity.ok(dto);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    // 옵션 등록 (관리자)
+    @PostMapping
+    public ResponseEntity<CategoryOptionResponseDto> createOption(@RequestBody CategoryOptionRequestDto dto) {
+        try {
+            CategoryOption saved = categoryOptionService.createOption(
+                    dto.getCategoryId(), dto.getCoName(), dto.getCoPrice(), dto.getCoTime());
+            CategoryOptionResponseDto response = CategoryOptionResponseDto.builder()
+                    .coId(saved.getCoId())
+                    .coName(saved.getCoName())
+                    .coPrice(saved.getCoPrice())
+                    .coTime(saved.getCoTime())
+                    .build();
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    // 옵션 수정 (관리자)
+    @PutMapping("/{coId}")
+    public ResponseEntity<CategoryOptionResponseDto> updateOption(@PathVariable Long coId, @RequestBody CategoryOptionRequestDto dto) {
+        try {
+            CategoryOption saved = categoryOptionService.updateOption(
+                    coId, dto.getCoName(), dto.getCoPrice(), dto.getCoTime());
+            CategoryOptionResponseDto response = CategoryOptionResponseDto.builder()
+                    .coId(saved.getCoId())
+                    .coName(saved.getCoName())
+                    .coPrice(saved.getCoPrice())
+                    .coTime(saved.getCoTime())
+                    .build();
+            return ResponseEntity.ok(response);
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    // 옵션 삭제 (관리자)
+    @DeleteMapping("/{coId}")
+    public ResponseEntity<Void> deleteOption(@PathVariable Long coId) {
+        try {
+            categoryOptionService.deleteOption(coId);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/api/ReservationController.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/ReservationController.java
@@ -1,5 +1,41 @@
 package com.antmen.antwork.common.api;
 
+import com.antmen.antwork.common.api.request.ReservationRequestDto;
+import com.antmen.antwork.common.api.response.ReservationResponseDto;
+import com.antmen.antwork.common.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/reservation")
+@RequiredArgsConstructor
 public class ReservationController {
 
+    private final ReservationService reservationService;
+
+    // 예약 생성
+    @PostMapping
+    public ResponseEntity<ReservationResponseDto> createReservation(
+            @RequestBody ReservationRequestDto requestDto) {
+        try {
+            ReservationResponseDto responseDto = reservationService.createReservation(requestDto);
+            return ResponseEntity.ok(responseDto);
+        } catch (Exception e) {
+            // 예외 처리 (간단 예시)
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    // 예약 단건 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<ReservationResponseDto> getReservation(@PathVariable Long id) {
+        try {
+            ReservationResponseDto responseDto = reservationService.getReservation(id);
+            return ResponseEntity.ok(responseDto);
+        } catch (Exception e) {
+            // 예외 처리 (간단 예시)
+            return ResponseEntity.notFound().build();
+        }
+    }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/api/request/CategoryOptionRequestDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/request/CategoryOptionRequestDto.java
@@ -1,0 +1,15 @@
+package com.antmen.antwork.common.api.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+
+@Getter
+@Setter
+@Builder
+public class CategoryOptionRequestDto {
+    private Long categoryId;
+    private String coName;
+    private Integer coPrice;
+    private Short coTime;
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/api/request/CategoryRequestDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/request/CategoryRequestDto.java
@@ -1,0 +1,14 @@
+package com.antmen.antwork.common.api.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+
+@Getter
+@Setter
+@Builder
+public class CategoryRequestDto {
+    private String categoryName;
+    private Long categoryPrice;
+    private Short categoryTime;
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/api/request/ReservationRequestDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/request/ReservationRequestDto.java
@@ -1,5 +1,23 @@
 package com.antmen.antwork.common.api.request;
 
-public class ReservationRequestDto {
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import java.sql.Time;
+import java.time.LocalDate;
 
+import com.antmen.antwork.common.domain.entity.Category;
+
+@Getter
+@Setter
+@Builder
+public class ReservationRequestDto {
+    private Long customerId; // 수요자 아이디
+    private LocalDate reservationCreatedAt; // 신청 날짜
+    private String reservationDate; // 예약 날짜
+    private Time reservationTime; // 예약 시간
+    private Category category; // 카테고리
+    private short reservationDuration; // 서비스 제공 시간
+    private String reservationMeno; // 추가 요청 사항 (엔티티와 이름 일치)
+    private Integer reservationAmount; // 최종 가격 (프론트에서 계산)
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/CategoryOptionResponseDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/CategoryOptionResponseDto.java
@@ -1,0 +1,15 @@
+package com.antmen.antwork.common.api.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+
+@Getter
+@Setter
+@Builder
+public class CategoryOptionResponseDto {
+    private Long coId;
+    private String coName;
+    private Integer coPrice;
+    private Short coTime;
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/CategoryResponseDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/CategoryResponseDto.java
@@ -1,0 +1,15 @@
+package com.antmen.antwork.common.api.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+
+@Getter
+@Setter
+@Builder
+public class CategoryResponseDto {
+    private Long categoryId;
+    private String categoryName;
+    private Long categoryPrice;
+    private Short categoryTime;
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/ReservationResponseDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/ReservationResponseDto.java
@@ -1,5 +1,28 @@
 package com.antmen.antwork.common.api.response;
 
-public class ReservationResponseDto {
+import lombok.Getter;
+import lombok.Setter;
+import lombok.Builder;
+import java.sql.Time;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import com.antmen.antwork.common.domain.entity.Category;
 
+@Getter
+@Setter
+@Builder
+public class ReservationResponseDto {
+    private Long reservationId; // 예약번호
+    private Long customerId; // 수요자 아이디
+    private LocalDate reservationCreatedAt; // 신청 날짜
+    private String reservationDate; // 예약 날짜
+    private Time reservationTime; // 예약 시간
+    private Category category; // 카테고리
+    private short reservationDuration; // 서비스 제공 시간
+    private Long managerId; // 매니저 아이디
+    private LocalDateTime managerAcceptTime; // 매니저 수락 시간
+    private String reservationStatus; // 예약 상태
+    private String reservationCancelReason; // 예약 취소 사유
+    private String reservationMeno; // 추가 요청 사항
+    private Integer reservationAmount; // 최종 가격
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/domain/entity/Category.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/domain/entity/Category.java
@@ -2,6 +2,8 @@ package com.antmen.antwork.common.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "category")
@@ -23,4 +25,7 @@ public class Category {
 
     @Column(nullable = false)
     private Short categoryTime;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    private List<CategoryOption> options = new ArrayList<>();
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/domain/entity/CategoryGroup.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/domain/entity/CategoryGroup.java
@@ -1,0 +1,23 @@
+package com.antmen.antwork.common.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "category_group")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryGroup {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long cgId;
+
+    @Column(nullable = false)
+    private Long reservationId;
+
+    @Column(nullable = false)
+    private Long categoryId;
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/domain/entity/CategoryOption.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/domain/entity/CategoryOption.java
@@ -1,0 +1,30 @@
+package com.antmen.antwork.common.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "category_option")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryOption {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long coId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Column(nullable = false)
+    private String coName;
+
+    @Column(nullable = false)
+    private Integer coPrice;
+
+    @Column(nullable = false)
+    private Short coTime;
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/CategoryGroupRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/CategoryGroupRepository.java
@@ -1,0 +1,12 @@
+package com.antmen.antwork.common.infra.repository;
+
+import com.antmen.antwork.common.domain.entity.CategoryGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CategoryGroupRepository extends JpaRepository<CategoryGroup, Long> {
+    List<CategoryGroup> findByReservationId(Long reservationId);
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/CategoryOptionRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/CategoryOptionRepository.java
@@ -1,0 +1,12 @@
+package com.antmen.antwork.common.infra.repository;
+
+import com.antmen.antwork.common.domain.entity.CategoryOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CategoryOptionRepository extends JpaRepository<CategoryOption, Long> {
+    List<CategoryOption> findByCategory_CategoryId(Long categoryId);
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/CategoryRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/CategoryRepository.java
@@ -1,0 +1,10 @@
+package com.antmen.antwork.common.infra.repository;
+
+import com.antmen.antwork.common.domain.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/ReservationRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/ReservationRepository.java
@@ -1,5 +1,10 @@
 package com.antmen.antwork.common.infra.repository;
 
-public class ReservationRepository {
+import com.antmen.antwork.common.domain.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+  
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/CategoryGroupService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/CategoryGroupService.java
@@ -1,0 +1,31 @@
+package com.antmen.antwork.common.service;
+
+import com.antmen.antwork.common.domain.entity.CategoryGroup;
+import com.antmen.antwork.common.infra.repository.CategoryGroupRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryGroupService {
+    private final CategoryGroupRepository categoryGroupRepository;
+
+    @Transactional
+    public void saveCategoryGroups(Long reservationId, List<Long> categoryIdList) {
+        for (Long categoryId : categoryIdList) {
+            CategoryGroup cg = CategoryGroup.builder()
+                    .reservationId(reservationId)
+                    .categoryId(categoryId)
+                    .build();
+            categoryGroupRepository.save(cg);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<CategoryGroup> getCategoryGroupsByReservationId(Long reservationId) {
+        return categoryGroupRepository.findByReservationId(reservationId);
+    }
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/service/CategoryOptionService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/CategoryOptionService.java
@@ -1,0 +1,61 @@
+package com.antmen.antwork.common.service;
+
+import com.antmen.antwork.common.domain.entity.CategoryOption;
+import com.antmen.antwork.common.domain.entity.Category;
+import com.antmen.antwork.common.infra.repository.CategoryOptionRepository;
+import com.antmen.antwork.common.infra.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryOptionService {
+    private final CategoryOptionRepository categoryOptionRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<CategoryOption> getOptionsByCategoryId(Long categoryId) {
+        return categoryOptionRepository.findByCategory_CategoryId(categoryId);
+    }
+
+    @Transactional(readOnly = true)
+    public CategoryOption getOption(Long coId) {
+        return categoryOptionRepository.findById(coId)
+                .orElseThrow(() -> new IllegalArgumentException("옵션을 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public CategoryOption createOption(Long categoryId, String coName, Integer coPrice, Short coTime) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+        CategoryOption option = CategoryOption.builder()
+                .category(category)
+                .coName(coName)
+                .coPrice(coPrice)
+                .coTime(coTime)
+                .build();
+        return categoryOptionRepository.save(option);
+    }
+
+    @Transactional
+    public CategoryOption updateOption(Long coId, String coName, Integer coPrice, Short coTime) {
+        CategoryOption option = getOption(coId);
+        option.setCoName(coName);
+        option.setCoPrice(coPrice);
+        option.setCoTime(coTime);
+        return categoryOptionRepository.save(option);
+    }
+
+    @Transactional
+    public void deleteOption(Long coId) {
+        categoryOptionRepository.deleteById(coId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CategoryOption> getAllOptions() {
+        return categoryOptionRepository.findAll();
+    }
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/service/CategoryService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/CategoryService.java
@@ -1,0 +1,45 @@
+package com.antmen.antwork.common.service;
+
+import com.antmen.antwork.common.domain.entity.Category;
+import com.antmen.antwork.common.infra.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    @Transactional(readOnly = true)
+    public List<Category> getAllCategories() {
+        return categoryRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Category getCategory(Long id) {
+        return categoryRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public Category createCategory(Category category) {
+        return categoryRepository.save(category);
+    }
+
+    @Transactional
+    public Category updateCategory(Long id, Category update) {
+        Category category = getCategory(id);
+        category.setCategoryName(update.getCategoryName());
+        category.setCategoryPrice(update.getCategoryPrice());
+        category.setCategoryTime(update.getCategoryTime());
+        return categoryRepository.save(category);
+    }
+
+    @Transactional
+    public void deleteCategory(Long id) {
+        categoryRepository.deleteById(id);
+    }
+} 

--- a/m-common/src/main/java/com/antmen/antwork/common/service/ReservationService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/ReservationService.java
@@ -1,5 +1,40 @@
 package com.antmen.antwork.common.service;
 
+import com.antmen.antwork.common.api.request.ReservationRequestDto;
+import com.antmen.antwork.common.api.response.ReservationResponseDto;
+import com.antmen.antwork.common.domain.entity.Reservation;
+import com.antmen.antwork.common.infra.repository.ReservationRepository;
+import com.antmen.antwork.common.service.mapper.ReservationMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class ReservationService {
 
+    private final ReservationRepository reservationRepository;
+    private final ReservationMapper reservationMapper;
+
+    @Transactional
+    public ReservationResponseDto createReservation(ReservationRequestDto requestDto) {
+        try {
+            Reservation reservation = reservationMapper.toEntity(requestDto);
+            Reservation saved = reservationRepository.save(reservation);
+            return reservationMapper.toDto(saved);
+        } catch (Exception e) {
+            throw new RuntimeException("예약 생성 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public ReservationResponseDto getReservation(Long id) {
+        try {
+            Reservation reservation = reservationRepository.findById(id)
+                    .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
+            return reservationMapper.toDto(reservation);
+        } catch (Exception e) {
+            throw new RuntimeException("예약 조회 중 오류가 발생했습니다.", e);
+        }
+    }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/mapper/ReservationMapper.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/mapper/ReservationMapper.java
@@ -1,5 +1,42 @@
 package com.antmen.antwork.common.service.mapper;
 
-public class ReservationMapper {
+import com.antmen.antwork.common.api.request.ReservationRequestDto;
+import com.antmen.antwork.common.api.response.ReservationResponseDto;
+import com.antmen.antwork.common.domain.entity.Reservation;
+import org.springframework.stereotype.Component;
 
+@Component
+public class ReservationMapper {
+    public Reservation toEntity(ReservationRequestDto dto) {
+        if (dto == null) return null;
+        return Reservation.builder()
+                .customerId(dto.getCustomerId())
+                .reservationCreatedAt(dto.getReservationCreatedAt())
+                .reservationDate(dto.getReservationDate())
+                .reservationTime(dto.getReservationTime())
+                .category(dto.getCategory())
+                .reservationDuration(dto.getReservationDuration())
+                .reservationMeno(dto.getReservationMeno())
+                .reservationAmount(dto.getReservationAmount())
+                .build();
+    }
+
+    public ReservationResponseDto toDto(Reservation entity) {
+        if (entity == null) return null;
+        return ReservationResponseDto.builder()
+                .reservationId(entity.getReservationId())
+                .customerId(entity.getCustomerId())
+                .reservationCreatedAt(entity.getReservationCreatedAt())
+                .reservationDate(entity.getReservationDate())
+                .reservationTime(entity.getReservationTime())
+                .category(entity.getCategory())
+                .reservationDuration(entity.getReservationDuration())
+                .managerId(entity.getManagerId())
+                .managerAcceptTime(entity.getManagerAcceptTime())
+                .reservationStatus(entity.getReservationStatus())
+                .reservationCancelReason(entity.getReservationCancelReason())
+                .reservationMeno(entity.getReservationMeno())
+                .reservationAmount(entity.getReservationAmount())
+                .build();
+    }
 }


### PR DESCRIPTION
## 주요 변경사항

### 1. 예약(Reservation) 기능
- Reservation 엔티티 및 DTO(Request/Response) 생성
- 예약 생성/조회 서비스 및 컨트롤러 구현 (POST/GET)
- ReservationMapper를 통한 DTO <-> Entity 변환 로직 추가
- ReservationRepository(JPA) 구현
- 예외처리, @Transactional, @Builder 등 코드 스타일 가이드 준수

### 2. 카테고리/옵션/그룹 관리
- Category, CategoryOption, CategoryGroup 엔티티 연관관계 및 JPA Repository 추가
- 카테고리(Category) CRUD 서비스/컨트롤러 및 DTO 구현
- 카테고리 옵션(CategoryOption) CRUD 서비스/컨트롤러 및 DTO 구현
- 카테고리 그룹(CategoryGroup) 서비스/컨트롤러 및 예약-카테고리 N:M 연동 API 구현
- 카테고리별 옵션 조회, 옵션 등록/수정/삭제/조회 API 구현
- 관리자/프론트에서 활용 가능한 구조로 설계

## 기타

- 추후 인증/인가(Spring Security 등) 추가 필요
- 추가 개선사항 및 피드백 환영합니다 👏