### PR TITLE
관리자 회원 검색 API 구현

### DIFF
--- a/m-admin/src/main/java/com/antmen/antwork/admin/AdminApplication.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/AdminApplication.java
@@ -15,7 +15,7 @@ public class AdminApplication {
     public static void main(String[] args) {
         // .env 파일 로드
         Dotenv dotenv = Dotenv.configure()
-                .directory("./")  // 루트 디렉토리의 .env 파일
+                .directory("../")  // 루트 디렉토리의 .env 파일
                 .ignoreIfMissing()
                 .load();
 

--- a/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminUserController.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminUserController.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 public class AdminUserController {
     private final UserService userService;
 
-    @GetMapping("/search")
+    @GetMapping
     public ResponseEntity<List<UserResponseDto>> searchUsers(
             @RequestParam(required = false) String name,
             @RequestParam(required = false) Long userId,

--- a/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminUserController.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminUserController.java
@@ -1,0 +1,39 @@
+package com.antmen.antwork.admin.controller;
+
+import com.antmen.antwork.common.api.response.account.UserResponseDto;
+import com.antmen.antwork.common.domain.entity.account.User;
+import com.antmen.antwork.common.domain.entity.account.UserRole;
+import com.antmen.antwork.common.service.serviceAccount.UserService;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/users")
+public class AdminUserController {
+    private final UserService userService;
+
+    @GetMapping("/search")
+    public ResponseEntity<List<UserResponseDto>> searchUsers(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) UserRole role
+    ) {
+        List<User> users = userService.searchUsers(name, userId, role);
+        List<UserResponseDto> result = users.stream()
+                .map(UserResponseDto::from)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<UserResponseDto> getUserById(@PathVariable Long userId) {
+        User user = userService.getUserById(userId);
+        return ResponseEntity.ok(UserResponseDto.from(user));
+    }
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/account/UserResponseDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/account/UserResponseDto.java
@@ -1,0 +1,46 @@
+package com.antmen.antwork.common.api.response.account;
+
+import com.antmen.antwork.common.domain.entity.account.User;
+import com.antmen.antwork.common.domain.entity.account.UserGender;
+import com.antmen.antwork.common.domain.entity.account.UserRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserResponseDto {
+
+    private Long userId;
+    private String userLoginId;
+    private String userName;
+    private String userTel;
+    private String userEmail;
+    private UserRole userRole;
+    private UserGender userGender;
+    private LocalDate userBirth;
+    private String userProfile;
+    private String userType;
+    private LocalDateTime userCreatedAt;
+
+    // 단방향이라 우선 dto안에서 처리할게요. 추후에 추가 기능 구현되면 분리
+    public static UserResponseDto from(User user) {
+        return UserResponseDto.builder()
+                .userId(user.getUserId())
+                .userLoginId(user.getUserLoginId())
+                .userName(user.getUserName())
+                .userTel(user.getUserTel())
+                .userEmail(user.getUserEmail())
+                .userRole(user.getUserRole())
+                .userGender(user.getUserGender())
+                .userBirth(user.getUserBirth())
+                .userProfile(user.getUserProfile())
+                .userType(user.getUserType())
+                .userCreatedAt(user.getUserCreatedAt())
+                .build();
+    }
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/account/UserRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/account/UserRepository.java
@@ -15,6 +15,16 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserLoginId(String userLoginId);
 
+    @Query("SELECT u FROM User u " +
+            "WHERE (:name IS NULL OR u.userName LIKE %:name%) " +
+            "AND (:userId IS NULL OR u.userId = :userId) " +
+            "AND (:role IS NULL OR u.userRole = :role)")
+    List<User> searchUsers(
+            @Param("name") String name,
+            @Param("userId") Long userId,
+            @Param("role") UserRole role
+    );
+
     List<User> findByUserRole(UserRole userRole);
 
     // 추후에 조건 추가 예정
@@ -24,5 +34,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "SELECT m.manager.userId FROM Matching m " +
             "WHERE m.reservation.reservationId = :reservationId))) ")
     List<Long> findTop3AvailableManagers(@Param("reservationId") Long reservationId, Pageable pageable);
-
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceAccount/UserService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceAccount/UserService.java
@@ -2,6 +2,8 @@ package com.antmen.antwork.common.service.serviceAccount;
 
 import com.antmen.antwork.common.domain.entity.account.User;
 import com.antmen.antwork.common.api.request.account.UserLoginDto;
+import com.antmen.antwork.common.domain.entity.account.UserRole;
+import com.antmen.antwork.common.domain.exception.NotFoundException;
 import com.antmen.antwork.common.infra.repository.account.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +11,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -42,5 +45,20 @@ public class UserService {
     public User getUserByUserLoginId(String userLoginId, String email, String gooGle) {
         User user = userRepository.findByUserLoginId(userLoginId).orElse(null);
         return user;
+    }
+
+    /**
+     * 회원 목록 조회 (페이징 처리, 역할 기반)
+     */
+    public List<User> searchUsers(String name, Long userId, UserRole role) {
+        return userRepository.searchUsers(name, userId, role);
+    }
+
+    /**
+     * 회원 단건 조회
+     */
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("해당 유저를 찾을 수 없습니다."));
     }
 }


### PR DESCRIPTION
## 🔧 주요 변경 사항
- 관리자 페이지에서 회원 목록을 이름, 회원 ID, 역할 기준으로 조회할 수 있도록 검색 API를 구현했습니다.

- AdminUserController에 조건 검색 API 추가
  - `/api/v1/admin/users` 엔드포인트에서 name, userId, userRole 파라미터로 검색
- UserService에 검색 로직 추가
- UserRepository에 조건 기반 검색 쿼리(`@Query`) 구현
- UserResponseDto로 결과 변환하여 프론트에 반환
- 프론트엔드에서 페이징 처리 부탁드립니다 :)
---

## 📎 API 예시
GET /api/v1/admin/users?name=홍길동&role=MANAGER