### PR TITLE
관리자 환불 조회 및 승인/거절 기능 구현

### DIFF
--- a/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminRefundController.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminRefundController.java
@@ -1,0 +1,34 @@
+package com.antmen.antwork.admin.controller;
+
+import com.antmen.antwork.common.api.response.reservation.RefundResponseDto;
+import com.antmen.antwork.common.service.serviceReservation.RefundService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/refunds")
+public class AdminRefundController {
+    private final RefundService refundService;
+
+    @GetMapping("/waiting")
+    public ResponseEntity<List<RefundResponseDto>> getWaitingRefunds() {
+        return ResponseEntity.ok(refundService.getWaitingRefunds());
+    }
+
+    @PutMapping("/{payId}/approve")
+    public ResponseEntity<Void> approveRefund(@PathVariable Long payId) {
+        refundService.approveRefund(payId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{payId}/reject")
+    public ResponseEntity<Void> rejectRefund(@PathVariable Long payId) {
+        refundService.rejectRefund(payId);
+        return ResponseEntity.ok().build();
+    }
+}
+

--- a/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminUserController.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminUserController.java
@@ -1,8 +1,10 @@
 package com.antmen.antwork.admin.controller;
 
+import com.antmen.antwork.common.api.response.account.ManagerResponseDto;
 import com.antmen.antwork.common.api.response.account.UserResponseDto;
 import com.antmen.antwork.common.domain.entity.account.User;
 import com.antmen.antwork.common.domain.entity.account.UserRole;
+import com.antmen.antwork.common.service.serviceAccount.ManagerService;
 import com.antmen.antwork.common.service.serviceAccount.UserService;
 import lombok.RequiredArgsConstructor;
 
@@ -17,7 +19,11 @@ import java.util.stream.Collectors;
 @RequestMapping("/api/v1/admin/users")
 public class AdminUserController {
     private final UserService userService;
+    private final ManagerService managerService;
 
+    /**
+     * 회원 목록 조회
+     */
     @GetMapping
     public ResponseEntity<List<UserResponseDto>> searchUsers(
             @RequestParam(required = false) String name,
@@ -31,9 +37,42 @@ public class AdminUserController {
         return ResponseEntity.ok(result);
     }
 
+    /**
+     * 회원 단건 조회
+     */
     @GetMapping("/{userId}")
     public ResponseEntity<UserResponseDto> getUserById(@PathVariable Long userId) {
         User user = userService.getUserById(userId);
         return ResponseEntity.ok(UserResponseDto.from(user));
+    }
+
+    /**
+     * 승인 대기 중인 매니저 조회
+     */
+    @GetMapping("/waiting-managers")
+    public ResponseEntity<List<ManagerResponseDto>> getWaitingManagers() {
+        List<ManagerResponseDto> waitingList = managerService.getWaitingManagers();
+        return ResponseEntity.ok(waitingList);
+    }
+
+    /**
+     * 매니저 가입 승인
+     */
+    @PostMapping("/{userId}/approve")
+    public ResponseEntity<Void> approveUser(@PathVariable Long userId) {
+        managerService.approveManager(userId);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 매니저 가입 거절
+     */
+    @PostMapping("/{userId}/reject")
+    public ResponseEntity<Void> rejectManager(
+            @PathVariable Long userId,
+            @RequestParam String reason
+    ) {
+        managerService.rejectManager(userId, reason);
+        return ResponseEntity.ok().build();
     }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/account/ManagerResponseDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/account/ManagerResponseDto.java
@@ -1,5 +1,6 @@
 package com.antmen.antwork.common.api.response.account;
 
+import com.antmen.antwork.common.domain.entity.account.ManagerStatus;
 import com.antmen.antwork.common.domain.entity.account.UserGender;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,4 +22,6 @@ public class ManagerResponseDto {
     private String managerArea;
     private String managerTime;
     private List<ManagerIdFileDto> managerFileUrls;
+    private ManagerStatus managerStatus;
+    private String rejectReason;
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/RefundResponseDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/RefundResponseDto.java
@@ -1,0 +1,32 @@
+package com.antmen.antwork.common.api.response.reservation;
+
+import com.antmen.antwork.common.domain.entity.reservation.Refund;
+import com.antmen.antwork.common.domain.entity.reservation.RefundStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RefundResponseDto {
+    private Long payId;
+    private Long userId;
+    private double refundAmount;
+    private String refundReason;
+    private RefundStatus refundStatus;
+    private LocalDateTime refundCreatedAt;
+    private LocalDateTime refundProcessedAt;
+
+    public static RefundResponseDto from(Refund refund) {
+        return RefundResponseDto.builder()
+                .payId(refund.getPayId())
+                .userId(refund.getPayment().getReservation().getCustomer().getUserId())
+                .refundAmount(refund.getRefundAmount())
+                .refundReason(refund.getRefundReason())
+                .refundStatus(refund.getRefundStatus())
+                .refundCreatedAt(refund.getRefundCreatedAt())
+                .refundProcessedAt(refund.getRefundProcessedAt())
+                .build();
+    }
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/domain/entity/account/ManagerDetail.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/domain/entity/account/ManagerDetail.java
@@ -28,4 +28,8 @@ public class ManagerDetail {
     @Column(nullable = false)
     private String managerTime; // Json
 
+    @Column(nullable = false)
+    private ManagerStatus managerStatus = ManagerStatus.WAITING;
+
+    private String rejectReason;
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/domain/entity/account/ManagerStatus.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/domain/entity/account/ManagerStatus.java
@@ -1,0 +1,7 @@
+package com.antmen.antwork.common.domain.entity.account;
+
+public enum ManagerStatus {
+    WAITING,
+    APPROVED,
+    REJECTED
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/domain/entity/reservation/Refund.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/domain/entity/reservation/Refund.java
@@ -34,7 +34,7 @@ public class Refund {
     private double refundAmount; // 환불 가능 금액
 
     @Column(nullable = false)
-    private String refundStatus; //W(Waiting): 환불대기, D(Done): 환불완료, R(Reject): 환불 거절
+    private RefundStatus refundStatus; // WAITING: 환불대기, APPROVED: 환불완료, REJECTED: 환불 거절
 
     private LocalDateTime refundProcessedAt; // 환불 최종 처리일
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/domain/entity/reservation/RefundStatus.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/domain/entity/reservation/RefundStatus.java
@@ -1,0 +1,7 @@
+package com.antmen.antwork.common.domain.entity.reservation;
+
+public enum RefundStatus {
+    WAITING,
+    APPROVED,
+    REJECTED,
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/RefundRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/RefundRepository.java
@@ -1,0 +1,14 @@
+package com.antmen.antwork.common.infra.repository.reservation;
+
+import com.antmen.antwork.common.domain.entity.reservation.Refund;
+import com.antmen.antwork.common.domain.entity.reservation.RefundStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+    List<Refund> findByRefundStatus(RefundStatus refundStatus);
+
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/service/mapper/account/ManagerMapper.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/mapper/account/ManagerMapper.java
@@ -39,6 +39,8 @@ public class ManagerMapper {
                                 .fileUrl(file.getManagerFileUrl())
                                 .build())
                         .collect(Collectors.toList()))
+                .managerStatus(managerDetail.getManagerStatus())
+                .rejectReason(managerDetail.getRejectReason())
                 .build();
     }
 

--- a/m-common/src/main/java/com/antmen/antwork/common/service/mapper/reservation/ReservationMapper.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/mapper/reservation/ReservationMapper.java
@@ -6,6 +6,7 @@ import com.antmen.antwork.common.domain.entity.reservation.Category;
 import com.antmen.antwork.common.domain.entity.reservation.Reservation;
 import com.antmen.antwork.common.domain.entity.reservation.ReservationOption;
 import com.antmen.antwork.common.domain.entity.account.User;
+import com.antmen.antwork.common.domain.entity.reservation.ReservationStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -29,6 +30,7 @@ public class ReservationMapper {
                 .reservationDate(dto.getReservationDate())
                 .reservationTime(dto.getReservationTime())
                 .reservationDuration(duration)
+                .reservationStatus(ReservationStatus.WAITING)
                 .reservationMemo(dto.getReservationMemo())
                 .reservationAmount(amount)
                 .build();

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceAccount/ManagerService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceAccount/ManagerService.java
@@ -2,10 +2,8 @@ package com.antmen.antwork.common.service.serviceAccount;
 
 import com.antmen.antwork.common.api.request.account.ManagerSignupRequestDto;
 import com.antmen.antwork.common.api.response.account.ManagerResponseDto;
-import com.antmen.antwork.common.domain.entity.account.ManagerDetail;
-import com.antmen.antwork.common.domain.entity.account.ManagerIdFile;
-import com.antmen.antwork.common.domain.entity.account.User;
-import com.antmen.antwork.common.domain.entity.account.UserRole;
+import com.antmen.antwork.common.domain.entity.account.*;
+import com.antmen.antwork.common.domain.exception.NotFoundException;
 import com.antmen.antwork.common.infra.repository.account.ManagerDetailRepository;
 import com.antmen.antwork.common.infra.repository.account.ManagerIdFileRepository;
 import com.antmen.antwork.common.infra.repository.account.UserRepository;
@@ -103,5 +101,59 @@ public class ManagerService {
         List<ManagerIdFile> idFiles = managerIdFileRepository.findAllByUser(user);
 
         return managerMapper.toDto(user, detail, idFiles);
+    }
+
+    /**
+     * 승인 대기 중인 매니저 조회
+     */
+    @Transactional(readOnly = true)
+    public List<ManagerResponseDto> getWaitingManagers() {
+        List<User> managerList = userRepository.findByUserRole(UserRole.MANAGER);
+
+        return managerList.stream()
+                .filter(user -> {
+                    ManagerDetail detail = managerDetailRepository.findByUser(user).orElse(null);
+                    return detail != null && detail.getManagerStatus() == ManagerStatus.WAITING;
+                })
+                .map(user -> {
+                    ManagerDetail detail = managerDetailRepository.findByUser(user).get();
+                    List<ManagerIdFile> idFiles = managerIdFileRepository.findAllByUser(user);
+                    return managerMapper.toDto(user, detail, idFiles);
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 매니저 가입 승인
+     */
+    @Transactional
+    public void approveManager(Long id) {
+        User user = userRepository.findById(id)
+                .filter(u -> u.getUserRole() == UserRole.MANAGER)
+                .orElseThrow(() -> new NotFoundException("매니저를 찾을 수 없습니다."));
+
+        ManagerDetail detail = managerDetailRepository.findByUser(user)
+                .orElseThrow(() -> new NotFoundException("매니저 상세 정보가 없습니다."));
+
+        detail.setManagerStatus(ManagerStatus.APPROVED);
+        detail.setRejectReason(null);
+    }
+
+    /**
+     * 매니저 가입 거절
+     * @param id
+     * @param reason
+     */
+    @Transactional
+    public void rejectManager(Long id, String reason) {
+        User user = userRepository.findById(id)
+                .filter(u -> u.getUserRole() == UserRole.MANAGER)
+                .orElseThrow(() -> new NotFoundException("매니저를 찾을 수 없습니다."));
+
+        ManagerDetail detail = managerDetailRepository.findByUser(user)
+                .orElseThrow(() -> new NotFoundException("매니저 상세 정보가 없습니다."));
+
+        detail.setManagerStatus(ManagerStatus.REJECTED);
+        detail.setRejectReason(reason);
     }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/RefundService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/RefundService.java
@@ -1,0 +1,39 @@
+package com.antmen.antwork.common.service.serviceReservation;
+
+import com.antmen.antwork.common.api.response.reservation.RefundResponseDto;
+import com.antmen.antwork.common.domain.entity.reservation.Refund;
+import com.antmen.antwork.common.domain.entity.reservation.RefundStatus;
+import com.antmen.antwork.common.domain.exception.NotFoundException;
+import com.antmen.antwork.common.infra.repository.reservation.RefundRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RefundService {
+    private final RefundRepository refundRepository;
+
+    public List<RefundResponseDto> getWaitingRefunds() {
+        return refundRepository.findByRefundStatus(RefundStatus.WAITING).stream()
+                .map(RefundResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    public void approveRefund(Long payId) {
+        Refund refund = refundRepository.findById(payId)
+                .orElseThrow(() -> new NotFoundException("해당 환불 내역이 존재하지 않습니다."));
+        refund.setRefundStatus(RefundStatus.APPROVED);
+        refund.setRefundProcessedAt(LocalDateTime.now());
+    }
+
+    public void rejectRefund(Long payId) {
+        Refund refund = refundRepository.findById(payId)
+                .orElseThrow(() -> new NotFoundException("해당 환불 내역이 존재하지 않습니다."));
+        refund.setRefundStatus(RefundStatus.REJECTED);
+        refund.setRefundProcessedAt(LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
Refund 엔티티 기반으로 환불 요청 로직 구현
- 환불 상태(RefundStatus) 관리: WAITING, APPROVED, REJECTED
- 관리자 전용 환불 목록 조회 API 추가
  - GET /api/v1/admin/refunds/waiting
- 환불 승인/거절 처리 API 추가
  - PUT /api/v1/admin/refunds/{payId}/approve
  - PUT /api/v1/admin/refunds/{payId}/reject
- RefundResponseDto 생성 및 사용자 ID(userId) 기준으로 응답 구성
  - Payment → Reservation → Customer 연관관계 추적