### PR TITLE
예약 상세 조회 및 매칭 구조 개선

### DIFF
--- a/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminReviewController.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminReviewController.java
@@ -1,0 +1,31 @@
+package com.antmen.antwork.admin.controller;
+
+import com.antmen.antwork.common.api.response.reservation.ReviewResponseDto;
+import com.antmen.antwork.common.service.serviceReservation.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/reviews")
+public class AdminReviewController {
+    private final ReviewService reviewService;
+
+    // 특정 유저에게 달린 리뷰 조회 (관리자용)
+    @GetMapping("/received/{userId}")
+    public ResponseEntity<List<ReviewResponseDto>> getReceivedReviews(@PathVariable Long userId) {
+        return ResponseEntity.ok(reviewService.getReviewsByUserId(userId));
+    }
+
+    // 전체 리뷰 조회 (관리자용)
+    @GetMapping
+    public ResponseEntity<List<ReviewResponseDto>> getAllReviews() {
+        return ResponseEntity.ok(reviewService.getAllReviews());
+    }
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/MatchingDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/MatchingDto.java
@@ -1,0 +1,32 @@
+package com.antmen.antwork.common.api.response.reservation;
+
+import com.antmen.antwork.common.domain.entity.reservation.Matching;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MatchingDto {
+    private Long matchingId;
+    private int priority;
+    private Boolean isRequested;
+    private Boolean isAccepted;
+    private Boolean isFinal;
+    private String refuseReason;
+
+    private UserSummaryDto manager;
+
+    public static MatchingDto from(Matching matching) {
+        return MatchingDto.builder()
+                .matchingId(matching.getMatchingId())
+                .priority(matching.getMatchingPriority())
+                .isRequested(matching.getMatchingIsRequest())
+                .isAccepted(matching.getMatchingManagerIsAccept())
+                .isFinal(matching.getMatchingIsFinal())
+                .refuseReason(matching.getMatchingRefuseReason())
+                .manager(UserSummaryDto.from(matching.getManager()))
+                .build();
+    }
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/ReservationDtoConverter.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/ReservationDtoConverter.java
@@ -1,0 +1,50 @@
+package com.antmen.antwork.common.api.response.reservation;
+
+import com.antmen.antwork.common.domain.entity.reservation.Matching;
+import com.antmen.antwork.common.domain.entity.reservation.Reservation;
+import com.antmen.antwork.common.domain.entity.reservation.ReservationOption;
+import com.antmen.antwork.common.infra.repository.reservation.MatchingRepository;
+import com.antmen.antwork.common.infra.repository.reservation.ReservationOptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationDtoConverter {
+    private final ReservationOptionRepository reservationOptionRepository;
+    private final MatchingRepository matchingRepository;
+
+    public ReservationHistoryDto toDto(Reservation reservation) {
+        List<ReservationOption> options = reservationOptionRepository.findByReservation_ReservationId(reservation.getReservationId());
+        List<Matching> matchings = matchingRepository.findAllByReservation_ReservationId(reservation.getReservationId());
+
+        String fullAddress = reservation.getAddress().getAddressAddr() + " " + reservation.getAddress().getAddressDetail();
+
+        return ReservationHistoryDto.builder()
+                .reservationId(reservation.getReservationId())
+                .categoryName(reservation.getCategory().getCategoryName())
+                .reservationStatus(reservation.getReservationStatus().name())
+                .reservationDate(reservation.getReservationDate().toString())
+                .totalDuration(reservation.getReservationDuration())
+                .totalAmount(reservation.getReservationAmount())
+                .customer(UserSummaryDto.from(reservation.getCustomer()))
+                .manager(reservation.getManager() != null ? UserSummaryDto.from(reservation.getManager()) : null)
+                .address(fullAddress)
+                .selectedOptions(options.stream()
+                        .map(o -> o.getCategoryOption().getCoName())
+                        .collect(Collectors.toList()))
+                .matchings(matchings.stream()
+                        .map(MatchingDto::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    public List<ReservationHistoryDto> convertToDtos(List<Reservation> reservations) {
+        return reservations.stream()
+                .map(this::toDto)
+                .collect(Collectors.toList());
+    }
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/ReservationHistoryDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/ReservationHistoryDto.java
@@ -1,0 +1,26 @@
+package com.antmen.antwork.common.api.response.reservation;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ReservationHistoryDto {
+    private Long reservationId;
+    private String categoryName;
+    private String reservationStatus;
+    private String reservationDate;
+    private short totalDuration;
+    private int totalAmount;
+
+    private UserSummaryDto customer;
+    private UserSummaryDto manager;
+    private String address;
+
+    private List<String> selectedOptions;
+    private List<MatchingDto> matchings;
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/ReservationResponseDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/ReservationResponseDto.java
@@ -25,7 +25,8 @@ public class ReservationResponseDto {
     private short reservationDuration;      // 서비스 제공 시간
 
     private Long managerId;                 // 매니저 아이디
-    private LocalDateTime matchedAt; // 매니저 수락 시간
+    private String managerName;             // 매니저 이름
+    private LocalDateTime matchedAt;        // 매니저 수락 시간
 
     private String reservationStatus;       // 예약 상태
     private String reservationCancelReason; // 예약 취소 사유

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/UserSummaryDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/UserSummaryDto.java
@@ -1,0 +1,31 @@
+package com.antmen.antwork.common.api.response.reservation;
+
+import com.antmen.antwork.common.domain.entity.account.User;
+import com.antmen.antwork.common.domain.entity.account.UserGender;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserSummaryDto {
+    private Long userId;
+    private String name;
+    private String gender;
+    private int age;
+    private String profileImage;
+
+    public static UserSummaryDto from(User user) {
+        return UserSummaryDto.builder()
+                .userId(user.getUserId())
+                .name(user.getUserName())
+                .gender(user.getUserGender() == UserGender.M ? "남성" : "여성")
+                .age(Period.between(user.getUserBirth(), LocalDate.now()).getYears())
+                .profileImage(user.getUserProfile())
+                .build();
+    }
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/domain/entity/reservation/Reservation.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/domain/entity/reservation/Reservation.java
@@ -1,5 +1,6 @@
 package com.antmen.antwork.common.domain.entity.reservation;
 
+import com.antmen.antwork.common.domain.entity.account.CustomerAddress;
 import com.antmen.antwork.common.domain.entity.account.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -33,6 +34,10 @@ public class Reservation {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manager_id")
     private User manager; // 매니저 아이디 (매칭이 되기 전까지는 null)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "address_id", nullable = false)
+    private CustomerAddress address; // 수요자 주소
 
     @Column(nullable = false)
     @CreationTimestamp

--- a/m-common/src/main/java/com/antmen/antwork/common/service/mapper/reservation/ReservationMapper.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/mapper/reservation/ReservationMapper.java
@@ -52,6 +52,7 @@ public class ReservationMapper {
                 .reservationId(entity.getReservationId())
                 .customerId(entity.getCustomer() != null ? entity.getCustomer().getUserId() : null)
                 .managerId(entity.getManager() != null ? entity.getManager().getUserId() : null)
+                .managerName(entity.getManager() != null ? entity.getManager().getUserName() : null)
                 .reservationCreatedAt(entity.getReservationCreatedAt())
                 .reservationDate(entity.getReservationDate())
                 .reservationTime(entity.getReservationTime())
@@ -59,16 +60,28 @@ public class ReservationMapper {
                 .categoryName(entity.getCategory() != null ? entity.getCategory().getCategoryName() : null)
                 .reservationDuration(entity.getReservationDuration())
                 .matchedAt(entity.getMatchedAt())
-                .reservationStatus(entity.getReservationStatus().name()) // "WAITING", "MATCHING"
+                .reservationStatus(mapToUiStatus(entity.getReservationStatus()))
                 .reservationCancelReason(entity.getReservationCancelReason())
                 .reservationMemo(entity.getReservationMemo())
                 .reservationAmount(entity.getReservationAmount())
                 .recommendDuration(recommendDuration)
+                .optionIds(optionIds)
+                .optionNames(optionNames)
                 .build();
     }
 
     public ReservationResponseDto toDto(Reservation reservation,
                                         List<ReservationOption> options) {
         return toDto(reservation, options, (short) 0);
+    }
+    private String mapToUiStatus(ReservationStatus status) {
+        if (status == null) return "UNKNOWN";
+        return switch (status) {
+            case WAITING, MATCHING -> "SCHEDULED";
+            case PAY -> "IN-PROGRESS";
+            case DONE -> "COMPLETED";
+            case CANCEL -> "CANCELLED";
+            case ERROR -> "ERROR";
+        };
     }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/rule/ServiceTimeAdvisor.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/rule/ServiceTimeAdvisor.java
@@ -27,3 +27,5 @@ public class ServiceTimeAdvisor {
         return (short) Math.max(round_remain, 1);
     }
 }
+
+// static으로 사용하거나

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
@@ -254,10 +254,11 @@ public class MatchingService {
         return userRepository.findByUserRole(UserRole.MANAGER).stream()
                 .map(MatchingManagerListResponseDto::toDto).toList();
     }
-
+    /*
+    선영: reservationService getReservationsByMatchingManager로 대체되는지 확인 부탁드립니다 :)
     // 매칭 요청 리스트 불러오기
     public List<ReservationResponseDto> getMatchingRequestList(Long managerId) {
         List<Reservation> reservationList = reservationRepository.findAllByManager(userRepository.findById(managerId).get());
         return reservationService.mapReservationsToDtos(reservationList);
-    }
+    }*/
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
@@ -34,7 +34,7 @@ public class MatchingService {
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
     private final AlertService alertService;
-    private final ReservationService reservationService;
+//    private final ReservationService reservationService;
 
     // 매칭 생성
     @Transactional

--- a/m-customer/src/main/java/com/antmen/antwork/customer/controller/CustomerReservationController.java
+++ b/m-customer/src/main/java/com/antmen/antwork/customer/controller/CustomerReservationController.java
@@ -2,6 +2,7 @@ package com.antmen.antwork.customer.controller;
 
 import com.antmen.antwork.common.api.request.reservation.ReservationCancelRequestDto;
 import com.antmen.antwork.common.api.request.reservation.ReservationRequestDto;
+import com.antmen.antwork.common.api.response.reservation.ReservationHistoryDto;
 import com.antmen.antwork.common.api.response.reservation.ReservationResponseDto;
 import com.antmen.antwork.common.service.serviceReservation.ReservationService;
 import com.antmen.antwork.common.util.AuthUserDto;
@@ -31,12 +32,22 @@ public class CustomerReservationController {
 
     /**
      * 예약 단건 조회
+     * 예약 폼 -> 예약 확인 페이지용
      */
     @GetMapping("/{id}")
     public ResponseEntity<ReservationResponseDto> getReservation(
             @PathVariable Long id) {
         ReservationResponseDto responseDto = reservationService.getReservation(id);
         return ResponseEntity.ok(responseDto);
+    }
+
+    /**
+     * 예약 상세 내역 조회 (주소 + 매칭 포함)
+     */
+    @GetMapping("/{id}/history")
+    public ResponseEntity<ReservationHistoryDto> getReservationDetail(
+            @PathVariable Long id) {
+        return ResponseEntity.ok(reservationService.getReservationDetail(id));
     }
 
     /**

--- a/m-manager/src/main/java/com/antmen/antwork/manager/controller/ManagerMatchingController.java
+++ b/m-manager/src/main/java/com/antmen/antwork/manager/controller/ManagerMatchingController.java
@@ -1,12 +1,16 @@
 package com.antmen.antwork.manager.controller;
 
 import com.antmen.antwork.common.api.request.reservation.MatchingManagerRequestDto;
+import com.antmen.antwork.common.api.response.reservation.ReservationHistoryDto;
 import com.antmen.antwork.common.service.serviceReservation.MatchingService;
+import com.antmen.antwork.common.service.serviceReservation.ReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/manager/matching")
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class ManagerMatchingController {
 
     public final MatchingService matchingService;
+    public final ReservationService reservationService;
 
     // 매니저의 매칭 확인
     @PutMapping("/{matchingId}")
@@ -22,12 +27,19 @@ public class ManagerMatchingController {
         return ResponseEntity.ok().build();
     }
 
+/* 우선 주석처리해서 빌드해놓을게용 :)
     // 매칭 리스트 불러오기
     @GetMapping("/list")
     public ResponseEntity getMatchingList(@AuthenticationPrincipal Long id) {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(matchingService.getMatchingRequestList(id));
+    }*/
+
+    // 매칭 예약 리스트 조회 대체 ( 추후 확인하시고 대체 부탁드립니다 :) )
+    @GetMapping("/list")
+    public ResponseEntity<List<ReservationHistoryDto>> getMatchingList(@AuthenticationPrincipal Long id) {
+        return ResponseEntity.ok(reservationService.getReservationsByMatchingManager(id));
     }
 
     // TODO: 예약 확인하기 -> 예약 단건 조회 이용할 수 있으면 이용하기

--- a/m-manager/src/main/java/com/antmen/antwork/manager/controller/ManagerReservationController.java
+++ b/m-manager/src/main/java/com/antmen/antwork/manager/controller/ManagerReservationController.java
@@ -1,6 +1,7 @@
 package com.antmen.antwork.manager.controller;
 
 import com.antmen.antwork.common.api.request.reservation.ReservationStatusChangeRequestDto;
+import com.antmen.antwork.common.api.response.reservation.ReservationHistoryDto;
 import com.antmen.antwork.common.api.response.reservation.ReservationResponseDto;
 import com.antmen.antwork.common.service.serviceReservation.ReservationService;
 import com.antmen.antwork.common.util.AuthUserDto;
@@ -36,6 +37,12 @@ public class ManagerReservationController {
     public ResponseEntity<ReservationResponseDto> getReservationById(@PathVariable Long id) {
         ReservationResponseDto responseDto = reservationService.getReservation(id);
         return ResponseEntity.ok(responseDto);
+    }
+
+    // 예약 상세 내역 조회 (주소 + 매칭 포함)
+    @GetMapping("/{id}/history")
+    public ResponseEntity<ReservationHistoryDto> getReservationDetail(@PathVariable Long id) {
+        return ResponseEntity.ok(reservationService.getReservationDetail(id));
     }
 
     /**


### PR DESCRIPTION
### 주요 변경 사항

#### ✅ 1. 예약 상세 조회 기능 추가
- ReservationService에 `getReservationDetail(Long)` 메서드 추가
  - 예약 + 매칭 + 주소 + 고객/매니저 요약 정보 포함
- ReservationDtoConverter를 통해 ReservationHistoryDto 반환
- CustomerReservationController, ManagerReservationController에 `/reservations/{id}/history` API 추가

#### ✅ 2. 매칭 구조 리팩터링 (스케줄러 기반 딜레이 매칭 대응)
- ReservationService에서 `matchingService.initiateMatching(...)` 호출 유지
  - 예약 직후 1순위 매니저에게 매칭 요청 전송
- 이후 2순위, 3순위 매니저는 MatchingScheduler에서 시간차 요청 처리
- MatchingService 내부에서 ReservationService 주입 제거하여 순환 참조 해결

#### ✅ 3. 불필요 메서드 제거
- MatchingService.getMatchingRequestList() 제거
  - ReservationService.getReservationsByMatchingManager()로 기능 대체

### 테스트 시나리오
- [ ] 예약 생성 시 1순위 매니저에게 즉시 알림이 가는지 확인
- [ ] `/reservations/{id}/history` API에서 예약 + 매칭 + 주소가 포함된 데이터가 반환되는지 확인
- [ ] 15분 후 응답이 없을 때, 스케줄러가 다음 매니저에게 매칭 요청 전송하는지 확인