### PR TITLE
매칭 오류 발견해서 긴급 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ subprojects {
 		implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 		runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 		runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+		// jpa
+		implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	}
 
 	tasks.withType(JavaCompile) {

--- a/m-common/build.gradle
+++ b/m-common/build.gradle
@@ -1,6 +1,4 @@
 dependencies {
-	// jpa
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	// mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
 

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/ReservationDtoConverter.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/ReservationDtoConverter.java
@@ -6,6 +6,7 @@ import com.antmen.antwork.common.domain.entity.reservation.ReservationOption;
 import com.antmen.antwork.common.infra.repository.reservation.MatchingRepository;
 import com.antmen.antwork.common.infra.repository.reservation.ReservationOptionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -42,9 +43,7 @@ public class ReservationDtoConverter {
                 .build();
     }
 
-    public List<ReservationHistoryDto> convertToDtos(List<Reservation> reservations) {
-        return reservations.stream()
-                .map(this::toDto)
-                .collect(Collectors.toList());
+    public Page<ReservationHistoryDto> convertToDtos(Page<Reservation> reservations) {
+        return reservations.map(this::toDto);
     }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface MatchingRepository extends JpaRepository<Matching, Long> {
+public interface MatchingRepository extends JpaRepository<Matching, Long>, MatchingRepositoryCustom {
 
     Optional<Matching> findTopByReservation_ReservationIdAndMatchingPriorityGreaterThanOrderByMatchingPriorityAsc(
             Long reservationId, int priority);
@@ -33,4 +33,5 @@ public interface MatchingRepository extends JpaRepository<Matching, Long> {
     List<Matching> findAllByManagerAndMatchingManagerIsAcceptTrue(User manager);
 
     List<Matching> findAllByManagerAndMatchingIsRequestTrue(User manager);
+
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepositoryCustom.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.antmen.antwork.common.infra.repository.reservation;
+
+import com.antmen.antwork.common.domain.entity.reservation.Reservation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MatchingRepositoryCustom {
+    Page<Reservation> findMatchingReservationByManagerId(Long userId, Pageable pageable);
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepositoryCustomImpl.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepositoryCustomImpl.java
@@ -1,0 +1,45 @@
+package com.antmen.antwork.common.infra.repository.reservation;
+
+import com.antmen.antwork.common.domain.entity.reservation.QMatching;
+import com.antmen.antwork.common.domain.entity.reservation.Reservation;
+import com.antmen.antwork.common.domain.entity.reservation.ReservationStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class MatchingRepositoryCustomImpl implements MatchingRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<Reservation> findMatchingReservationByManagerId(Long userId, Pageable pageable) {
+        QMatching qMatching = QMatching.matching;
+
+        BooleanExpression condition = qMatching.manager.userId.eq(userId)
+                .and(qMatching.matchingIsRequest.isTrue())
+                .and(qMatching.matchingManagerIsAccept.isNull())
+                .and(qMatching.reservation.reservationStatus.eq(ReservationStatus.WAITING));
+
+        List<Reservation> reservations = jpaQueryFactory
+                .select(qMatching.reservation)
+                .from(qMatching)
+                .where(condition)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = jpaQueryFactory
+                .select(qMatching.count())
+                .from(qMatching)
+                .where(condition)
+                .fetchOne();
+
+        return new PageImpl<Reservation>(reservations, pageable, total);
+    }
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/ReservationService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/ReservationService.java
@@ -254,7 +254,9 @@ public class ReservationService {
 
         List<Matching> matchings = matchingRepository.findAllByManagerAndMatchingIsRequestTrue(manager);
         List<Reservation> reservations = matchings.stream()
-                .map(Matching::getReservation).collect(Collectors.toList());
+                .map(Matching::getReservation)
+                .filter(reservation -> reservation.getReservationStatus() == ReservationStatus.WAITING)
+                .collect(Collectors.toList());
         return reservationDtoConverter.convertToDtos(reservations);
     }
 

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/ReservationService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/ReservationService.java
@@ -18,6 +18,8 @@ import com.antmen.antwork.common.service.mapper.reservation.ReservationMapper;
 import com.antmen.antwork.common.service.rule.ServiceTimeAdvisor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -248,16 +250,18 @@ public class ReservationService {
      * 매칭 내역 + 기본 예약 정보 포함
      */
     @Transactional(readOnly = true)
-    public List<ReservationHistoryDto> getReservationsByMatchingManager(Long managerId) {
+    public Page<ReservationHistoryDto> getReservationsByMatchingManager(Long managerId, Pageable pageable) {
         User manager = userRepository.findById(managerId)
                 .orElseThrow(() -> new NotFoundException("해당 매니저가 존재하지 않습니다."));
 
-        List<Matching> matchings = matchingRepository.findAllByManagerAndMatchingIsRequestTrue(manager);
-        List<Reservation> reservations = matchings.stream()
-                .map(Matching::getReservation)
-                .filter(reservation -> reservation.getReservationStatus() == ReservationStatus.WAITING)
-                .collect(Collectors.toList());
-        return reservationDtoConverter.convertToDtos(reservations);
+//        List<Matching> matchings = matchingRepository.findAllByManagerAndMatchingIsRequestTrue(manager);
+//        List<Reservation> reservations = matchings.stream()
+//                .map(Matching::getReservation)
+//                .filter(reservation -> reservation.getReservationStatus() == ReservationStatus.WAITING)
+//                .collect(Collectors.toList());
+
+        Page<Reservation> reservationPage = matchingRepository.findMatchingReservationByManagerId(managerId, pageable);
+        return reservationDtoConverter.convertToDtos(reservationPage);
     }
 
     /**

--- a/m-manager/src/main/java/com/antmen/antwork/manager/controller/ManagerMatchingController.java
+++ b/m-manager/src/main/java/com/antmen/antwork/manager/controller/ManagerMatchingController.java
@@ -2,14 +2,12 @@ package com.antmen.antwork.manager.controller;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.antmen.antwork.common.api.request.reservation.MatchingManagerRequestDto;
 import com.antmen.antwork.common.api.response.reservation.ReservationHistoryDto;
@@ -48,14 +46,18 @@ public class ManagerMatchingController {
      */
 
     @GetMapping("/list")
-    public ResponseEntity<List<ReservationHistoryDto>> getMatchingList(
-            @AuthenticationPrincipal AuthUserDto authUserDto) {
+    public ResponseEntity<Page<ReservationHistoryDto>> getMatchingList(
+            @AuthenticationPrincipal AuthUserDto authUserDto,
+            @RequestParam(defaultValue = "0") int page) {
 
         if (authUserDto == null || authUserDto.getUserIdAsLong() == null) {
             throw new IllegalArgumentException("인증 정보가 없습니다.");
         }
+
         Long managerId = authUserDto.getUserIdAsLong();
-        return ResponseEntity.ok(reservationService.getReservationsByMatchingManager(managerId));
+
+        Pageable pageable = PageRequest.of(page, 5);
+        return ResponseEntity.ok(reservationService.getReservationsByMatchingManager(managerId, pageable));
     }
 
     // TODO: 예약 확인하기 -> 예약 단건 조회 이용할 수 있으면 이용하기


### PR DESCRIPTION
매칭 거절이 안되길래 수정했습니다.

원인: 매니저가 응답한 매칭과 고객이 취소한 예약이 내 매칭에 표출됨.
해결: 백단에서 DB조회 시 조건 더 추가.
- 예약 상태가 waiting일 것
- 요청은 왔으나 매니저가 응답하지 않았을 것

기왕 수정하는 김에 페이지 네이션도 적용했습니다. 한번에 5개씩 조회합니다.