### PR TITLE
matching algorithm : 자동매칭, 거리순 정렬

### DIFF
--- a/m-common/src/main/java/com/antmen/antwork/common/api/request/reservation/MatchingRequestDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/request/reservation/MatchingRequestDto.java
@@ -15,6 +15,7 @@ import java.util.List;
 @Builder
 @ToString
 public class MatchingRequestDto {
+    private Long reservationId;
     private Long addressId;                         // 기본 주소 ID (프론트에서 선택)
     private LocalDate reservationDate;              // 예약 날짜
     private LocalTime reservationTime;              // 예약 시간

--- a/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/MatchingManagerListResponseDto.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/api/response/reservation/MatchingManagerListResponseDto.java
@@ -17,13 +17,12 @@ public class MatchingManagerListResponseDto {
     private String managerName;
     private String managerGender;
     private Integer managerAge;
-    // TODO: 태그로 바꾸고 싶은데 흠,,,
     private String managerComment;
     private double managerRating;
     private String managerImage;
+    private Double distance;
 
-    // TODO: 매개변수 더 추가될 것으로 예상
-    public static MatchingManagerListResponseDto toDto(User user) {
+    public static MatchingManagerListResponseDto toDto(User user, Double distance) {
         return MatchingManagerListResponseDto.builder()
                 .managerId(user.getUserId())
                 .managerName(user.getUserName())
@@ -34,6 +33,10 @@ public class MatchingManagerListResponseDto {
                 // TODO: 타 테이블과 연동 필요
                 .managerRating(0.0)
                 .managerImage(user.getUserProfile())
+                .distance(distance)
                 .build();
+    }
+    public static MatchingManagerListResponseDto toDto(User user) {
+        return toDto(user, null);
     }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/account/ManagerDetailRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/account/ManagerDetailRepository.java
@@ -1,6 +1,7 @@
 package com.antmen.antwork.common.infra.repository.account;
 
 import com.antmen.antwork.common.domain.entity.account.ManagerDetail;
+import com.antmen.antwork.common.domain.entity.account.ManagerStatus;
 import com.antmen.antwork.common.domain.entity.account.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,4 +40,6 @@ public interface ManagerDetailRepository extends JpaRepository<ManagerDetail, Lo
     );
 
     List<ManagerDetail> findByUserIdIn(List<Long> userIds);
+
+    List<ManagerDetail> findByManagerStatus(ManagerStatus managerStatus);
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/AlertService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/AlertService.java
@@ -30,7 +30,6 @@ public class AlertService {
 
         for (Alert alert : unReadAlertList) {
             alert.setIsRead(true);
-            alertRepository.save(alert);
         }
     }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
@@ -23,17 +23,19 @@ import com.antmen.antwork.common.infra.repository.reservation.MatchingRepository
 import com.antmen.antwork.common.service.AlertService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.Manager;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static jdk.internal.org.jline.utils.Log.warn;
 
 @Slf4j
 @Service
@@ -87,14 +89,6 @@ public class MatchingService {
                     .alertTrigger("Matching")
                     .build());
         }
-    }
-
-    // 자동추천 3명
-    // 이건 재매칭 때 사용하는 걸로
-    @Transactional
-    public List<Long> selectTop3Candidate(Reservation reservation) {
-        // TODO: 추후에 조건추가 예정
-        return userRepository.findTop3AvailableManagers(reservation.getReservationId(), PageRequest.of(0, 3));
     }
 
     // 다음 매칭 요청
@@ -266,62 +260,30 @@ public class MatchingService {
     // 매칭 신청 가능한 매니저 리스트 조회 (시간)
     @Transactional(readOnly = true)
     public List<MatchingManagerListResponseDto> getManagerList(MatchingRequestDto requestDto, boolean useDistanceFilter, String sortType) {
-        int startTime = requestDto.getReservationTime().getHour() * 60 + requestDto.getReservationTime().getMinute();
-        int endTime = startTime + requestDto.getReservationDuration() * 60;
+        List<User> filteredManager = getFilteredManagers(
+                requestDto.getReservationDate(),
+                requestDto.getReservationTime(),
+                requestDto.getReservationDuration(),
+                requestDto.getAddressId(),
+                useDistanceFilter
+        );
+        return sortManagerDtos(filteredManager.stream()
+                .map(MatchingManagerListResponseDto::toDto).toList(),sortType);
+    }
 
-         // 시간순 (기본) : 수요자 예약 시간 기준 겹치는 매니저 제외
-        List<Long> busyManagerIds = reservationRepository.findBusyManagerIds(
-                requestDto.getReservationDate(), startTime, endTime);
-        List<User> availableManagers = busyManagerIds.isEmpty()
-                ? userRepository.findByUserRole(UserRole.MANAGER)
-                : userRepository.findByUserRoleAndUserIdNotIn(UserRole.MANAGER, busyManagerIds);
-
-        // 분기 처리 (시간, 시간+거리)
-       if (!useDistanceFilter) {
-           return sortManagerDtos(availableManagers.stream()
-                   .map(MatchingManagerListResponseDto::toDto)
-                   .toList(), sortType);
-       }
-
-        // 거리순 : 수요자 기준 10km 이내 필터링
-        CustomerAddress customerAddress = customerAddressRepository.findById(requestDto.getAddressId())
-                .orElseThrow(() -> new NotFoundException("고객 주소가 존재하지 않습니다."));
-        if (customerAddress.getCustomerLatitude() == null || customerAddress.getCustomerLongitude() == null) {
-            throw new IllegalArgumentException("고객 주소에 위경도 정보가 없습니다.");}
-
-        double customerLat = customerAddress.getCustomerLatitude();
-        double customerLng = customerAddress.getCustomerLongitude();
-        double rangeKm = 10.0;
-
-        List<Long> userIds = availableManagers.stream().map(User::getUserId).toList();
-        List<ManagerDetail> managerDetails = managerDetailRepository.findByUserIdIn(userIds);
-
-        List<MatchingManagerListResponseDto> filtered = managerDetails.stream()
-                .filter(detail -> {
-                    if (detail.getManagerLatitude() == null || detail.getManagerLongitude() == null) {
-                        log.warn("위경도 정보가 누락된 매니저: userId={}", detail.getUserId());
-                        return false;
-                    }
-                    return true;
-                })
-                .filter(detail -> calculateDistance(customerLat, customerLng,
-                        detail.getManagerLatitude(),
-                        detail.getManagerLongitude()) <= rangeKm)
-                .map(detail -> {
-                    User matchedUser = availableManagers.stream()
-                            .filter(u -> u.getUserId().equals(detail.getUserId()))
-                            .findFirst()
-                            .orElse(null);
-                    if (matchedUser == null) {
-                        log.warn("userId={} 에 해당하는 User 객체를 찾을 수 없습니다.", detail.getUserId());
-                        return null;
-                    }
-                    return MatchingManagerListResponseDto.toDto(matchedUser);
-                })
-                .filter(Objects::nonNull)
-                .toList();
-
-        return sortManagerDtos(filtered, sortType);
+    // 자동추천 3명
+    @Transactional
+    public List<MatchingManagerListResponseDto> selectTop3Candidate(MatchingRequestDto requestDto, String sortType) {
+        List<User> filteredManager = getFilteredManagers(
+                requestDto.getReservationDate(),
+                requestDto.getReservationTime(),
+                requestDto.getReservationDuration(),
+                requestDto.getAddressId(),
+                true
+        );
+        List<MatchingManagerListResponseDto> sortedDtos = sortManagerDtos(filteredManager.stream()
+                .map(MatchingManagerListResponseDto::toDto).toList(),sortType);
+        return sortedDtos.stream().limit(3).toList();
     }
 
     private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
@@ -336,6 +298,7 @@ public class MatchingService {
         double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
         return EARTH_RADIUS_KM * c;
     }
+
     private List<MatchingManagerListResponseDto> sortManagerDtos(List<MatchingManagerListResponseDto> dtos, String sortType) {
         return switch (sortType.toLowerCase()) {
             // todo: 리뷰 기반 정렬은 reviewSummary 기능 구현 후 활성화 진행할게용
@@ -348,5 +311,48 @@ public class MatchingService {
             case "distance" -> dtos;
             default -> dtos;
         };
+    }
+
+    private List<User> getFilteredManagers(LocalDate date, LocalTime time, int duration, Long addressId, boolean useDistanceFilter) {
+        int startTime = time.getHour() * 60 + time.getMinute();
+        int endTime = startTime + duration * 60;
+
+        List<Long> busyManagerIds = reservationRepository.findBusyManagerIds(date, startTime, endTime);
+        List<User> availableManagers = busyManagerIds.isEmpty()
+                ? userRepository.findByUserRole(UserRole.MANAGER)
+                : userRepository.findByUserRoleAndUserIdNotIn(UserRole.MANAGER, busyManagerIds);
+
+        if (!useDistanceFilter) {
+            return availableManagers;
+        }
+        CustomerAddress customerAddress = customerAddressRepository.findById(addressId)
+                .orElseThrow(() -> new NotFoundException("고객 주소가 존재하지 않습니다."));
+        if (customerAddress.getCustomerLatitude() == null || customerAddress.getCustomerLongitude() == null) {
+            throw new NotFoundException("고객 주소에 위경도가 존재하지 않습니다.");
+        }
+
+        double customerLat = customerAddress.getCustomerLatitude();
+        double customerLng = customerAddress.getCustomerLongitude();
+        double rangeKm = 10.0;
+
+        List<Long> userIds = availableManagers.stream().map(User::getUserId).toList();
+        List<ManagerDetail> managerDetails = managerDetailRepository.findByUserIdIn(userIds);
+        Map<Long, User> userMap = availableManagers.stream()
+                .collect(Collectors.toMap(User::getUserId, Function.identity()));
+
+        return managerDetails.stream()
+                .filter(detail -> {
+                    if (detail.getManagerLatitude() == null || detail.getManagerLongitude() == null) {
+                        log.warn("위경도 정보가 누락된 매니저: userId={}", detail.getUserId());
+                        return false;
+                    }
+                    return true;
+                })
+                .filter(detail -> calculateDistance(customerLat, customerLng,
+                        detail.getManagerLatitude(),
+                        detail.getManagerLongitude()) <= rangeKm)
+                .map(detail -> userMap.get(detail.getUserId()))
+                .filter(Objects::nonNull)
+                .toList();
     }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
@@ -78,13 +78,12 @@ public class MatchingService {
 
         // 1순위에게 알림 전송
         if (!matchingList.isEmpty()) {
-            Matching top = matchingList.get(0); // 우선순위대로 추가했으므로 첫 번째가 최우선
+            Matching top = matchingList.get(0); // 우선 순위대로 추가했으므로 첫 번째가 최우선
             top.setMatchingIsRequest(true);
             top.setMatchingUpdatedAt(LocalDateTime.now());
 
             alertService.sendAlert(AlertRequestDto.builder()
                     .userId(top.getManager().getUserId())
-                    // 예약 상세내용도 보내줘야하나?
                     .alertContent("매칭 요청이 왔어요.")
                     .alertTrigger("Matching")
                     .build());
@@ -138,7 +137,6 @@ public class MatchingService {
 
         alertService.sendAlert(AlertRequestDto.builder()
                 .userId(nextMatching.getManager().getUserId())
-                // 예약 상세내용도 보내줘야하나?
                 .alertContent("매칭 요청이 왔어요.")
                 .alertTrigger("Matching")
                 .build());

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
@@ -35,8 +35,6 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static jdk.internal.org.jline.utils.Log.warn;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -54,26 +52,37 @@ public class MatchingService {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new IllegalArgumentException("예약이 존재하지 않습니다."));
 
+        MatchingRequestDto matchingRequestDto = MatchingRequestDto.builder()
+                .reservationId(reservation.getReservationId())
+                .addressId(reservation.getAddress().getAddressId())
+                .reservationDate(reservation.getReservationDate())
+                .reservationTime(reservation.getReservationTime())
+                .reservationDuration(reservation.getReservationDuration())
+                .build();
+
+        // 자동추천
+        List<Long> selectedManagerIds = (managerIds == null || managerIds.isEmpty())
+                ? selectTop3Candidate(matchingRequestDto, "distance").stream()
+                .map(MatchingManagerListResponseDto::getManagerId)
+                .toList()
+                : managerIds;
+
         List<Matching> matchingList = new ArrayList<>();
         int basePriority = 1;
 
-        // 자동추천
-        if (managerIds == null || managerIds.isEmpty()) {
-            managerIds = selectTop3Candidate(reservation);
-        }
 
-        for (Long managerId : managerIds) {
+        for (Long managerId : selectedManagerIds) {
+            User manager = userRepository.findById(managerId)
+                    .orElseThrow(() -> new IllegalArgumentException("매니저가 없습니다."));
             Matching matching = Matching.builder()
                     .reservation(reservation)
-                    .manager(userRepository.findById(managerId)
-                            .orElseThrow(() -> new IllegalArgumentException("매니저가 없습니다.")))
+                    .manager(manager)
                     .matchingPriority(basePriority++)
                     .matchingIsRequest(false)
                     .matchingUpdatedAt(LocalDateTime.now())
                     .build();
             matchingList.add(matching);
         }
-
         matchingRepository.saveAll(matchingList);
 
         // 1순위에게 알림 전송
@@ -94,55 +103,71 @@ public class MatchingService {
     @Transactional
     public void triggerNextMatching(Matching rejectedMatching) {
         Long reservationId = rejectedMatching.getReservation().getReservationId();
+        Reservation reservation = rejectedMatching.getReservation();
         int currentPriority = rejectedMatching.getMatchingPriority();
 
-        Matching nextMatching = matchingRepository
-                .findTopByReservation_ReservationIdAndMatchingPriorityGreaterThanOrderByMatchingPriorityAsc(
-                        reservationId, currentPriority)
-                .orElse(null);
+        Matching nextMatching = null;
+        int tryPriority = currentPriority + 1;
 
-        // 다음 매칭이 없으면 새로운 매칭 생성
-        if (nextMatching == null) {
-            log.info("🔁 새로운 매칭 생성: reservationId={}, currentPriority={},", reservationId, currentPriority + 1);
-            List<Long> newManagers = selectTop3Candidate(rejectedMatching.getReservation());
-            List<Matching> newMatchings = new ArrayList<>();
-            int basePriority = currentPriority + 1;
-
-            for (Long managerId : newManagers) {
-                Matching matching = Matching.builder()
-                        .reservation(rejectedMatching.getReservation())
-                        .manager(userRepository.findById(managerId)
-                                .orElseThrow(() -> new IllegalArgumentException("매니저가 없습니다.")))
-                        .matchingPriority(basePriority++)
-                        .matchingIsRequest(false)
-                        .matchingUpdatedAt(LocalDateTime.now())
-                        .build();
-                newMatchings.add(matching);
-            }
-            matchingRepository.saveAll(newMatchings);
-
-            // 매칭할 매니저가 없다면 어떻게 처리할 것인지 고민 필요
+        while (true) {
             nextMatching = matchingRepository
                     .findTopByReservation_ReservationIdAndMatchingPriorityGreaterThanOrderByMatchingPriorityAsc(
-                            reservationId, currentPriority)
+                            reservationId, tryPriority - 1)
                     .orElse(null);
+
+            // 다음 매칭이 없으면 새 매칭 생성 시도
+            if (nextMatching == null) {
+                log.info("🔁 새로운 매칭 생성: reservationId={}, currentPriority={}", reservationId, tryPriority);
+
+                MatchingRequestDto matchingRequestDto = MatchingRequestDto.builder()
+                        .reservationId(reservation.getReservationId())
+                        .addressId(reservation.getAddress().getAddressId())
+                        .reservationDate(reservation.getReservationDate())
+                        .reservationTime(reservation.getReservationTime())
+                        .reservationDuration(reservation.getReservationDuration())
+                        .build();
+
+                List<Long> newManagerIds = selectTop3Candidate(matchingRequestDto, "distance").stream()
+                        .map(MatchingManagerListResponseDto::getManagerId).toList();
+
+                int newPriority = tryPriority;
+                List<Matching> newMatchings = new ArrayList<>();
+                for (Long managerId : newManagerIds) {
+                    User manager = userRepository.findById(managerId)
+                            .orElseThrow(() -> new IllegalArgumentException("매니저가 없습니다."));
+                    Matching newMatching = Matching.builder()
+                            .reservation(reservation)
+                            .manager(manager)
+                            .matchingPriority(newPriority++)
+                            .matchingIsRequest(false)
+                            .matchingUpdatedAt(LocalDateTime.now())
+                            .build();
+                    newMatchings.add(newMatching);
+                }
+                matchingRepository.saveAll(newMatchings);
+
+                nextMatching = newMatchings.isEmpty() ? null : newMatchings.get(0);
+            }
+
+            if (nextMatching == null) {
+                log.info("매칭할 수 있는 매니저가 더 이상 없습니다.");
+                return;}
+
+            if (!Boolean.TRUE.equals(nextMatching.getMatchingIsRequest())) {
+                nextMatching.setMatchingIsRequest(true);
+                nextMatching.setMatchingUpdatedAt(LocalDateTime.now());
+
+                alertService.sendAlert(AlertRequestDto.builder()
+                        .userId(nextMatching.getManager().getUserId())
+                        .alertContent("매칭 요청이 왔어요.")
+                        .alertTrigger("Matching")
+                        .build());
+                return;
+            }
+
+            // 이미 요청된 경우 다음 순위로
+            tryPriority++;
         }
-
-        if (nextMatching != null && nextMatching.getMatchingIsRequest() == true) {
-            // 찍히지 않기를 바라지만 찍힌다면 로직 재점검 필요
-            log.warn("🚫 매칭이 이미 요청된 매칭입니다. reservationId={}, currentPriority={}", reservationId, currentPriority + 1);
-            triggerNextMatching(nextMatching);
-            return;
-        }
-
-        alertService.sendAlert(AlertRequestDto.builder()
-                .userId(nextMatching.getManager().getUserId())
-                .alertContent("매칭 요청이 왔어요.")
-                .alertTrigger("Matching")
-                .build());
-
-        nextMatching.setMatchingIsRequest(true);
-        nextMatching.setMatchingUpdatedAt(LocalDateTime.now());
     }
 
     // 매니저 매칭 답장
@@ -263,7 +288,9 @@ public class MatchingService {
                 requestDto.getReservationTime(),
                 requestDto.getReservationDuration(),
                 requestDto.getAddressId(),
-                useDistanceFilter
+                useDistanceFilter,
+                null,
+                false
         );
         return sortManagerDtos(filteredManager.stream()
                 .map(MatchingManagerListResponseDto::toDto).toList(),sortType);
@@ -277,6 +304,8 @@ public class MatchingService {
                 requestDto.getReservationTime(),
                 requestDto.getReservationDuration(),
                 requestDto.getAddressId(),
+                true,
+                requestDto.getReservationId(),
                 true
         );
         List<MatchingManagerListResponseDto> sortedDtos = sortManagerDtos(filteredManager.stream()
@@ -284,6 +313,12 @@ public class MatchingService {
         return sortedDtos.stream().limit(3).toList();
     }
 
+    /**
+     * 매칭 유틸 메소드
+     * 1. 위경도 계산 calculateDistance
+     * 2. 정렬 (리뷰, 최근 가입순, 거리순) sortManagerDtos
+     * 3. 매칭 추천 (시간, 거리 적용) getFilteredManagers
+     */
     private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
         final int EARTH_RADIUS_KM = 6371;
         double dLat = Math.toRadians(lat2 - lat1);
@@ -291,7 +326,7 @@ public class MatchingService {
 
         double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
                 + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
-                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+                + Math.sin(dLon / 2) * Math.sin(dLon / 2);
 
         double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
         return EARTH_RADIUS_KM * c;
@@ -311,46 +346,60 @@ public class MatchingService {
         };
     }
 
-    private List<User> getFilteredManagers(LocalDate date, LocalTime time, int duration, Long addressId, boolean useDistanceFilter) {
+    private List<User> getAvailableManagers(LocalDate date, LocalTime time, int duration) {
         int startTime = time.getHour() * 60 + time.getMinute();
         int endTime = startTime + duration * 60;
-
         List<Long> busyManagerIds = reservationRepository.findBusyManagerIds(date, startTime, endTime);
-        List<User> availableManagers = busyManagerIds.isEmpty()
+
+        return busyManagerIds.isEmpty()
                 ? userRepository.findByUserRole(UserRole.MANAGER)
                 : userRepository.findByUserRoleAndUserIdNotIn(UserRole.MANAGER, busyManagerIds);
+    }
 
-        if (!useDistanceFilter) {
-            return availableManagers;
-        }
-        CustomerAddress customerAddress = customerAddressRepository.findById(addressId)
+    private List<User> excludeAlreadyMatchedManagers(List<User> candidates, Long reservationId) {
+        if (reservationId == null) return candidates;
+
+        List<Long> alreadyMatched = matchingRepository.findAllByReservation_ReservationId(reservationId).stream()
+                .map(m -> m.getManager().getUserId())
+                .toList();
+
+        return candidates.stream()
+                .filter(user -> !alreadyMatched.contains(user.getUserId()))
+                .toList();
+    }
+
+    private List<User> filterManagersByDistance(List<User> managers, Long addressId) {
+        CustomerAddress address = customerAddressRepository.findById(addressId)
                 .orElseThrow(() -> new NotFoundException("고객 주소가 존재하지 않습니다."));
-        if (customerAddress.getCustomerLatitude() == null || customerAddress.getCustomerLongitude() == null) {
+
+        if (address.getCustomerLatitude() == null || address.getCustomerLongitude() == null) {
             throw new NotFoundException("고객 주소에 위경도가 존재하지 않습니다.");
         }
 
-        double customerLat = customerAddress.getCustomerLatitude();
-        double customerLng = customerAddress.getCustomerLongitude();
+        double lat = address.getCustomerLatitude();
+        double lng = address.getCustomerLongitude();
         double rangeKm = 10.0;
 
-        List<Long> userIds = availableManagers.stream().map(User::getUserId).toList();
-        List<ManagerDetail> managerDetails = managerDetailRepository.findByUserIdIn(userIds);
-        Map<Long, User> userMap = availableManagers.stream()
-                .collect(Collectors.toMap(User::getUserId, Function.identity()));
+        Map<Long, User> userMap = managers.stream().collect(Collectors.toMap(User::getUserId, Function.identity()));
+        List<ManagerDetail> managerDetails = managerDetailRepository.findByUserIdIn(userMap.keySet().stream().toList());
 
         return managerDetails.stream()
-                .filter(detail -> {
-                    if (detail.getManagerLatitude() == null || detail.getManagerLongitude() == null) {
-                        log.warn("위경도 정보가 누락된 매니저: userId={}", detail.getUserId());
-                        return false;
-                    }
-                    return true;
-                })
-                .filter(detail -> calculateDistance(customerLat, customerLng,
-                        detail.getManagerLatitude(),
-                        detail.getManagerLongitude()) <= rangeKm)
-                .map(detail -> userMap.get(detail.getUserId()))
+                .filter(d -> d.getManagerLatitude() != null && d.getManagerLongitude() != null)
+                .filter(d -> calculateDistance(lat, lng, d.getManagerLatitude(), d.getManagerLongitude()) <= rangeKm)
+                .map(d -> userMap.get(d.getUserId()))
                 .filter(Objects::nonNull)
                 .toList();
+    }
+
+    private List<User> getFilteredManagers(LocalDate date, LocalTime time, int duration, Long addressId, boolean useDistanceFilter, Long reservationId, boolean excludeAlreadyMatched) {
+        List<User> availableManagers = getAvailableManagers(date, time, duration);
+
+        if (excludeAlreadyMatched && reservationId != null) {
+            availableManagers = excludeAlreadyMatchedManagers(availableManagers, reservationId);}
+
+        if (useDistanceFilter) {
+            availableManagers = filterManagersByDistance(availableManagers, addressId);}
+
+        return availableManagers;
     }
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
@@ -323,10 +323,12 @@ public class MatchingService {
         final int EARTH_RADIUS_KM = 6371;
         double dLat = Math.toRadians(lat2 - lat1);
         double dLon = Math.toRadians(lon2 - lon1);
+        double rLat1 = Math.toRadians(lat1);
+        double rLat2 = Math.toRadians(lat2);
 
         double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
-                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
-                + Math.sin(dLon / 2) * Math.sin(dLon / 2);
+                + Math.cos(rLat1) * Math.cos(rLat2)
+                * Math.sin(dLon / 2) * Math.sin(dLon / 2);
 
         double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
         return EARTH_RADIUS_KM * c;
@@ -371,10 +373,8 @@ public class MatchingService {
     private List<User> filterManagersByDistance(List<User> managers, Long addressId) {
         CustomerAddress address = customerAddressRepository.findById(addressId)
                 .orElseThrow(() -> new NotFoundException("고객 주소가 존재하지 않습니다."));
-
         if (address.getCustomerLatitude() == null || address.getCustomerLongitude() == null) {
-            throw new NotFoundException("고객 주소에 위경도가 존재하지 않습니다.");
-        }
+            throw new NotFoundException("고객 주소에 위경도가 존재하지 않습니다.");}
 
         double lat = address.getCustomerLatitude();
         double lng = address.getCustomerLongitude();
@@ -396,7 +396,6 @@ public class MatchingService {
 
         if (excludeAlreadyMatched && reservationId != null) {
             availableManagers = excludeAlreadyMatchedManagers(availableManagers, reservationId);}
-
         if (useDistanceFilter) {
             availableManagers = filterManagersByDistance(availableManagers, addressId);}
 

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
@@ -7,10 +7,7 @@ import com.antmen.antwork.common.api.request.alert.AlertRequestDto;
 import com.antmen.antwork.common.api.request.reservation.MatchingCancelRequestDto;
 import com.antmen.antwork.common.api.response.reservation.MatchingManagerListResponseDto;
 import com.antmen.antwork.common.api.response.reservation.ReservationResponseDto;
-import com.antmen.antwork.common.domain.entity.account.CustomerAddress;
-import com.antmen.antwork.common.domain.entity.account.ManagerDetail;
-import com.antmen.antwork.common.domain.entity.account.User;
-import com.antmen.antwork.common.domain.entity.account.UserRole;
+import com.antmen.antwork.common.domain.entity.account.*;
 import com.antmen.antwork.common.domain.entity.reservation.Matching;
 import com.antmen.antwork.common.domain.entity.reservation.Reservation;
 import com.antmen.antwork.common.domain.entity.reservation.ReservationStatus;
@@ -283,7 +280,7 @@ public class MatchingService {
     // 매칭 신청 가능한 매니저 리스트 조회 (시간)
     @Transactional(readOnly = true)
     public List<MatchingManagerListResponseDto> getManagerList(MatchingRequestDto requestDto, boolean useDistanceFilter, String sortType) {
-        List<User> filteredManager = getFilteredManagers(
+        List<MatchingManagerListResponseDto> filteredManager = getFilteredManagers(
                 requestDto.getReservationDate(),
                 requestDto.getReservationTime(),
                 requestDto.getReservationDuration(),
@@ -292,14 +289,13 @@ public class MatchingService {
                 null,
                 false
         );
-        return sortManagerDtos(filteredManager.stream()
-                .map(MatchingManagerListResponseDto::toDto).toList(),sortType);
+        return sortManagerDtos(filteredManager,sortType);
     }
 
     // 자동추천 3명
     @Transactional
     public List<MatchingManagerListResponseDto> selectTop3Candidate(MatchingRequestDto requestDto, String sortType) {
-        List<User> filteredManager = getFilteredManagers(
+        List<MatchingManagerListResponseDto> filteredManager = getFilteredManagers(
                 requestDto.getReservationDate(),
                 requestDto.getReservationTime(),
                 requestDto.getReservationDuration(),
@@ -308,9 +304,7 @@ public class MatchingService {
                 requestDto.getReservationId(),
                 true
         );
-        List<MatchingManagerListResponseDto> sortedDtos = sortManagerDtos(filteredManager.stream()
-                .map(MatchingManagerListResponseDto::toDto).toList(),sortType);
-        return sortedDtos.stream().limit(3).toList();
+        return sortManagerDtos(filteredManager,sortType).stream().limit(3).toList();
     }
 
     /**
@@ -343,7 +337,9 @@ public class MatchingService {
             case "recent" -> dtos.stream()
                     .sorted(Comparator.comparing(MatchingManagerListResponseDto::getManagerId).reversed())
                     .toList();
-            case "distance" -> dtos;
+            case "distance" -> dtos.stream()
+                    .sorted(Comparator.comparingDouble(dto -> Optional.ofNullable(dto.getDistance()).orElse(Double.MAX_VALUE)))
+                    .toList();
             default -> dtos;
         };
     }
@@ -353,9 +349,15 @@ public class MatchingService {
         int endTime = startTime + duration * 60;
         List<Long> busyManagerIds = reservationRepository.findBusyManagerIds(date, startTime, endTime);
 
-        return busyManagerIds.isEmpty()
+        List<User> baseManagers = busyManagerIds.isEmpty()
                 ? userRepository.findByUserRole(UserRole.MANAGER)
                 : userRepository.findByUserRoleAndUserIdNotIn(UserRole.MANAGER, busyManagerIds);
+
+        List<Long> approvedManagerIds = managerDetailRepository.findByManagerStatus(ManagerStatus.APPROVED).stream()
+                .map(ManagerDetail::getUserId).toList();
+        return baseManagers.stream()
+                .filter(user -> approvedManagerIds.contains(user.getUserId()))
+                .toList();
     }
 
     private List<User> excludeAlreadyMatchedManagers(List<User> candidates, Long reservationId) {
@@ -370,7 +372,7 @@ public class MatchingService {
                 .toList();
     }
 
-    private List<User> filterManagersByDistance(List<User> managers, Long addressId) {
+    private List<MatchingManagerListResponseDto> filterManagersByDistance(List<User> managers, Long addressId) {
         CustomerAddress address = customerAddressRepository.findById(addressId)
                 .orElseThrow(() -> new NotFoundException("고객 주소가 존재하지 않습니다."));
         if (address.getCustomerLatitude() == null || address.getCustomerLongitude() == null) {
@@ -385,20 +387,25 @@ public class MatchingService {
 
         return managerDetails.stream()
                 .filter(d -> d.getManagerLatitude() != null && d.getManagerLongitude() != null)
-                .filter(d -> calculateDistance(lat, lng, d.getManagerLatitude(), d.getManagerLongitude()) <= rangeKm)
-                .map(d -> userMap.get(d.getUserId()))
+                .map(d -> {
+                    double distance = calculateDistance(lat, lng, d.getManagerLatitude(), d.getManagerLongitude());
+                    if (distance > rangeKm) return null;
+
+                    User user = userMap.get(d.getUserId());
+                    return user != null ? MatchingManagerListResponseDto.toDto(user, distance) : null;
+                })
                 .filter(Objects::nonNull)
                 .toList();
     }
 
-    private List<User> getFilteredManagers(LocalDate date, LocalTime time, int duration, Long addressId, boolean useDistanceFilter, Long reservationId, boolean excludeAlreadyMatched) {
+    private List<MatchingManagerListResponseDto> getFilteredManagers(LocalDate date, LocalTime time, int duration, Long addressId, boolean useDistanceFilter, Long reservationId, boolean excludeAlreadyMatched) {
         List<User> availableManagers = getAvailableManagers(date, time, duration);
 
         if (excludeAlreadyMatched && reservationId != null) {
             availableManagers = excludeAlreadyMatchedManagers(availableManagers, reservationId);}
         if (useDistanceFilter) {
-            availableManagers = filterManagersByDistance(availableManagers, addressId);}
+            return filterManagersByDistance(availableManagers, addressId);}
 
-        return availableManagers;
+        return availableManagers.stream().map(MatchingManagerListResponseDto::toDto).toList();
     }
 }


### PR DESCRIPTION
### 자동 매칭
- 거리순 + 예약 가능한 매니저 중 상위 3명 자동매칭

### 재매칭 로직 개선 (거절시 재매칭)
- 무한 루프 개선
- MatchingRequestDto로 변환하여 동일한 필터 및 정렬 기준 재사용
- 기존 매칭된 매니저 제외 로직 적용

### 거리 로직 구현
- 거리 계산 후 가까운 순서대로 정렬 (sortType=distance일 경우)
- 거리 필터를 적용하면 후보 매니저 리스트에 거리 정보가 포함됨
- 기존 잘못된 위경도 계산식을 수정하여 정확한 거리 산출

추가 사항
- 매니저 승인 상태 필터링 적용
ManagerDetail.managerStatus = APPROVED인 매니저만 필터링

