### PR TITLE
매칭 로직 개선: 매니저·수요자 거절 시 즉시 다음 매칭 요청 전송

### DIFF
--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepository.java
@@ -21,14 +21,18 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
 
     List<Matching> findAllByReservation_ReservationId(Long reservationId);
 
-    @Query("SELECT m FROM Matching m " +
-            "WHERE m.matchingIsRequest = true " +
-            "AND m.matchingManagerIsAccept IS NULL " +
-            "AND m.matchingUpdatedAt < :threshold " +
-            "ORDER BY m.matchingPriority DESC " +
-            "LIMIT 1" +
-            "")
-    List<Matching> findLatestPendingMatchings(@Param("threshold") LocalDateTime threshold);
+    @Query("""
+        SELECT m FROM Matching m
+        WHERE m.matchingIsRequest = true
+          AND m.matchingIsFinal IS NULL
+          AND m.matchingUpdatedAt < :threshold
+          AND m.reservation.reservationStatus = 'WAITING'
+          AND m.reservation.address.addressId >= :minAddressId
+    """)
+    List<Matching> findLatestPendingMatchings(
+            @Param("threshold") LocalDateTime threshold,
+            @Param("minAddressId") Long minAddressId
+    );
 
     List<Matching> findAllByManagerAndMatchingManagerIsAcceptTrue(User manager);
 

--- a/m-common/src/main/java/com/antmen/antwork/common/service/scheduler/MatchingScheduler.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/scheduler/MatchingScheduler.java
@@ -1,104 +1,116 @@
-package com.antmen.antwork.common.service.scheduler;
-
-import com.antmen.antwork.common.api.request.alert.AlertRequestDto;
-import com.antmen.antwork.common.domain.entity.reservation.Matching;
-import com.antmen.antwork.common.domain.entity.reservation.Reservation;
-import com.antmen.antwork.common.domain.entity.reservation.ReservationStatus;
-import com.antmen.antwork.common.infra.repository.reservation.MatchingRepository;
-import com.antmen.antwork.common.service.AlertService;
-import com.antmen.antwork.common.service.serviceReservation.MatchingService;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.List;
-
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class MatchingScheduler {
-    private final MatchingRepository matchingRepository;
-    private final MatchingService matchingService;
-    private final AlertService alertService;
-
-    // 제한 시간동안 매니저가 답장이 없을 때
-    @Scheduled(fixedDelay = 60000)
-    @Transactional
-    public void expireUnanweredMatchingRequests() {
-        log.info("매니저 요청 추가 전송 스케줄러 시작");
-        LocalDateTime threshold = LocalDateTime.now().minusMinutes(1); // 테스트용 1분으로 수정할게용
-
-        List<Matching> expiredMatchings = matchingRepository
-                .findLatestPendingMatchings(threshold);
-
-        for (Matching matching : expiredMatchings) {
-            if (matching.getReservation().getReservationStatus() == ReservationStatus.WAITING) {
-                matchingService.triggerNextMatching(matching);
-            }
-        }
-    }
-
-    // 제한 시간 동안 수요자가 답장이 없을 때
-    @Scheduled(fixedRate = 60000)
-    @Transactional
-    public void pendingUnansweredCustomerMatching() {
-        log.info("무응답 사용자 예약 취소 스케줄러 작동 시작!");
-        List<Matching> pendingCustomerMatchings = matchingRepository
-                .findAllByMatchingManagerIsAcceptIsTrueAndMatchingIsFinalIsNull();
-
-        for (Matching matching : pendingCustomerMatchings) {
-            Reservation reservation = matching.getReservation();
-
-            LocalDateTime baseTime = matching.getMatchingUpdatedAt();
-            LocalDateTime now = LocalDateTime.now();
-            Duration untilWork = Duration.between(
-                    now,
-                    LocalDateTime.of(reservation.getReservationDate(), reservation.getReservationTime())
-            );
-
-            Duration allowed = untilWork.toHours() >= 24
-                    ? Duration.ofHours(24)
-                    : Duration.ofHours(1);
-
-            Duration diff = Duration.between(baseTime, now);
-
-            if (diff.compareTo(allowed) > 0) {
-                log.info("⏰ 수요자 응답 시간 초과 → 자동 거절: matchingId={}, reservationId={}, ",matching.getMatchingId(), reservation.getReservationId());
-                matching.setMatchingIsFinal(false);
-                reservation.setReservationCancelReason("자동 거절 (수요자 응답 시간 초과)");
-
-                reservation.setReservationStatus(ReservationStatus.CANCEL);
-
-                alertService.sendAlert(AlertRequestDto.builder()
-                                .alertContent("매칭 요청에 응답하지 않아 자동으로 예약이 취소되었습니다.")
-                                .alertTrigger("Matching")
-                        .build());
-
-                matching.setMatchingUpdatedAt(LocalDateTime.now());
-            }
-
-            // 취소된 예약에 대해 매니저들에게 예약 취소 알람
-            List<Matching> requestedMatching = matchingRepository.findAllByReservation_ReservationId(reservation.getReservationId());
-
-            for (Matching m : requestedMatching) {
-                m.setMatchingIsFinal(false);
-                m.setMatchingRefuseReason("자동 거절 (수요자 응답 시간 초과)");
-                m.setMatchingUpdatedAt(LocalDateTime.now());
-                if (m.getMatchingIsRequest()) {
-                    if (m.getMatchingManagerIsAccept() || m.getMatchingManagerIsAccept() == null) {
-                        alertService.sendAlert(AlertRequestDto.builder()
-                                .userId(m.getManager().getUserId())
-                                .alertContent("고객이 취소한 예약입니다.")
-                                .alertTrigger("Matching")
-                                .build());
-                    }
-                }
-            }
-        }
-
-    }
-}
+//package com.antmen.antwork.common.service.scheduler;
+//
+//import com.antmen.antwork.common.api.request.alert.AlertRequestDto;
+//import com.antmen.antwork.common.domain.entity.reservation.Matching;
+//import com.antmen.antwork.common.domain.entity.reservation.Reservation;
+//import com.antmen.antwork.common.domain.entity.reservation.ReservationStatus;
+//import com.antmen.antwork.common.infra.repository.reservation.MatchingRepository;
+//import com.antmen.antwork.common.service.AlertService;
+//import com.antmen.antwork.common.service.serviceReservation.MatchingService;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.scheduling.annotation.Scheduled;
+//import org.springframework.stereotype.Component;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import java.time.Duration;
+//import java.time.LocalDateTime;
+//import java.util.List;
+//
+//@Slf4j
+//@Component
+//@RequiredArgsConstructor
+//public class MatchingScheduler {
+//    private final MatchingRepository matchingRepository;
+//    private final MatchingService matchingService;
+//    private final AlertService alertService;
+//
+//    // 제한 시간동안 매니저가 답장이 없을 때
+//    @Scheduled(fixedDelay = 60000)
+//    @Transactional
+//    public void expireUnanweredMatchingRequests() {
+//        log.info("매니저 요청 추가 전송 스케줄러 시작");
+//        LocalDateTime threshold = LocalDateTime.now().minusMinutes(1); // 테스트용 1분으로 수정할게용
+//        Long minAddressId = 31L;
+//        List<Matching> expiredMatchings = matchingRepository
+//                .findLatestPendingMatchings(threshold, minAddressId);
+//
+//        log.info("[Scheduler] 실행된 예약 수: {}", expiredMatchings.size());
+//        for (Matching matching : expiredMatchings) {
+//            log.info("[Scheduler] 만료된 매칭 ID: {}, 예약 ID: {}, isRequested={}, isAccepted={}, isFinal={}",
+//                    matching.getMatchingId(),
+//                    matching.getReservation().getReservationId(),
+//                    matching.getMatchingIsRequest(),
+//                    matching.getMatchingManagerIsAccept(),
+//                    matching.getMatchingIsFinal()
+//            );
+//            if (matching.getReservation().getReservationStatus() == ReservationStatus.WAITING) {
+//                log.info("[Scheduler] 트리거 실행 → matchingId={}, priority={}", matching.getMatchingId(), matching.getMatchingPriority());
+//                matchingService.triggerNextMatching(matching);
+//            }else {
+//                log.info("[Scheduler] 예약 상태가 WAITING 아님 → reservationId={}, 상태={}",
+//                        matching.getReservation().getReservationId(),
+//                        matching.getReservation().getReservationStatus());
+//            }
+//        }
+//    }
+//
+//    // 제한 시간 동안 수요자가 답장이 없을 때
+//    @Scheduled(fixedRate = 60000)
+//    @Transactional
+//    public void pendingUnansweredCustomerMatching() {
+//        log.info("무응답 사용자 예약 취소 스케줄러 작동 시작!");
+//        List<Matching> pendingCustomerMatchings = matchingRepository
+//                .findAllByMatchingManagerIsAcceptIsTrueAndMatchingIsFinalIsNull();
+//
+//        for (Matching matching : pendingCustomerMatchings) {
+//            Reservation reservation = matching.getReservation();
+//
+//            LocalDateTime baseTime = matching.getMatchingUpdatedAt();
+//            LocalDateTime now = LocalDateTime.now();
+//            Duration untilWork = Duration.between(
+//                    now,
+//                    LocalDateTime.of(reservation.getReservationDate(), reservation.getReservationTime())
+//            );
+//
+//            Duration allowed = untilWork.toHours() >= 24
+//                    ? Duration.ofHours(24)
+//                    : Duration.ofHours(1);
+//
+//            Duration diff = Duration.between(baseTime, now);
+//
+//            if (diff.compareTo(allowed) > 0) {
+//                log.info("⏰ 수요자 응답 시간 초과 → 자동 거절: matchingId={}, reservationId={}, ",matching.getMatchingId(), reservation.getReservationId());
+//                matching.setMatchingIsFinal(false);
+//                reservation.setReservationCancelReason("자동 거절 (수요자 응답 시간 초과)");
+//
+//                reservation.setReservationStatus(ReservationStatus.CANCEL);
+//
+//                alertService.sendAlert(AlertRequestDto.builder()
+//                                .userId(reservation.getCustomer().getUserId())
+//                                .alertContent("매칭 요청에 응답하지 않아 자동으로 예약이 취소되었습니다.")
+//                                .alertTrigger("Matching")
+//                        .build());
+//
+//                matching.setMatchingUpdatedAt(LocalDateTime.now());
+//            }
+//
+//            // 취소된 예약에 대해 매니저들에게 예약 취소 알람
+//            List<Matching> requestedMatching = matchingRepository.findAllByReservation_ReservationId(reservation.getReservationId());
+//
+//            for (Matching m : requestedMatching) {
+//                m.setMatchingIsFinal(false);
+//                m.setMatchingRefuseReason("자동 거절 (수요자 응답 시간 초과)");
+//                m.setMatchingUpdatedAt(LocalDateTime.now());
+//                if (m.getMatchingIsRequest() &&
+//                        (m.getMatchingManagerIsAccept() == null || Boolean.TRUE.equals(m.getMatchingManagerIsAccept()))) {
+//                        alertService.sendAlert(AlertRequestDto.builder()
+//                                .userId(m.getManager().getUserId())
+//                                .alertContent("고객이 취소한 예약입니다.")
+//                                .alertTrigger("Matching")
+//                                .build());
+//                    }
+//                }
+//            }
+//        }
+//    }

--- a/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/service/serviceReservation/MatchingService.java
@@ -99,57 +99,17 @@ public class MatchingService {
     // 다음 매칭 요청
     @Transactional
     public void triggerNextMatching(Matching rejectedMatching) {
-        Long reservationId = rejectedMatching.getReservation().getReservationId();
         Reservation reservation = rejectedMatching.getReservation();
+        Long reservationId = reservation.getReservationId();
         int currentPriority = rejectedMatching.getMatchingPriority();
 
-        Matching nextMatching = null;
-        int tryPriority = currentPriority + 1;
+        // 다음 매칭 후보 찾기
+        Optional<Matching> optionalNext = matchingRepository
+                .findTopByReservation_ReservationIdAndMatchingPriorityGreaterThanOrderByMatchingPriorityAsc(
+                        reservationId, currentPriority);
 
-        while (true) {
-            nextMatching = matchingRepository
-                    .findTopByReservation_ReservationIdAndMatchingPriorityGreaterThanOrderByMatchingPriorityAsc(
-                            reservationId, tryPriority - 1)
-                    .orElse(null);
-
-            // 다음 매칭이 없으면 새 매칭 생성 시도
-            if (nextMatching == null) {
-                log.info("🔁 새로운 매칭 생성: reservationId={}, currentPriority={}", reservationId, tryPriority);
-
-                MatchingRequestDto matchingRequestDto = MatchingRequestDto.builder()
-                        .reservationId(reservation.getReservationId())
-                        .addressId(reservation.getAddress().getAddressId())
-                        .reservationDate(reservation.getReservationDate())
-                        .reservationTime(reservation.getReservationTime())
-                        .reservationDuration(reservation.getReservationDuration())
-                        .build();
-
-                List<Long> newManagerIds = selectTop3Candidate(matchingRequestDto, "distance").stream()
-                        .map(MatchingManagerListResponseDto::getManagerId).toList();
-
-                int newPriority = tryPriority;
-                List<Matching> newMatchings = new ArrayList<>();
-                for (Long managerId : newManagerIds) {
-                    User manager = userRepository.findById(managerId)
-                            .orElseThrow(() -> new IllegalArgumentException("매니저가 없습니다."));
-                    Matching newMatching = Matching.builder()
-                            .reservation(reservation)
-                            .manager(manager)
-                            .matchingPriority(newPriority++)
-                            .matchingIsRequest(false)
-                            .matchingUpdatedAt(LocalDateTime.now())
-                            .build();
-                    newMatchings.add(newMatching);
-                }
-                matchingRepository.saveAll(newMatchings);
-
-                nextMatching = newMatchings.isEmpty() ? null : newMatchings.get(0);
-            }
-
-            if (nextMatching == null) {
-                log.info("매칭할 수 있는 매니저가 더 이상 없습니다.");
-                return;
-            }
+        if (optionalNext.isPresent()) {
+            Matching nextMatching = optionalNext.get();
 
             if (!Boolean.TRUE.equals(nextMatching.getMatchingIsRequest())) {
                 nextMatching.setMatchingIsRequest(true);
@@ -160,12 +120,64 @@ public class MatchingService {
                         .alertContent("매칭 요청이 왔어요.")
                         .alertTrigger("Matching")
                         .build());
-                return;
+
+                log.info("➡️ 다음 매니저에게 매칭 요청 전송: reservationId={}, matchingId={}, priority={}",
+                        reservationId, nextMatching.getMatchingId(), nextMatching.getMatchingPriority());
+            } else {
+                log.info("❗ 다음 매니저는 이미 요청됨 → 무시: reservationId={}, priority={}", reservationId, nextMatching.getMatchingPriority());
             }
 
-            // 이미 요청된 경우 다음 순위로
-            tryPriority++;
+            return;
         }
+
+        // 다음 매칭이 없으면 새 매칭 생성 (재추천)
+        log.info("🔁 새로운 매칭 생성: reservationId={}, fromPriority={}", reservationId, currentPriority + 1);
+
+        MatchingRequestDto dto = MatchingRequestDto.builder()
+                .reservationId(reservationId)
+                .addressId(reservation.getAddress().getAddressId())
+                .reservationDate(reservation.getReservationDate())
+                .reservationTime(reservation.getReservationTime())
+                .reservationDuration(reservation.getReservationDuration())
+                .build();
+
+        List<Long> recommendedIds = selectTop3Candidate(dto, "distance")
+                .stream()
+                .map(MatchingManagerListResponseDto::getManagerId)
+                .toList();
+
+        int newPriority = currentPriority + 1;
+        for (Long managerId : recommendedIds) {
+            User manager = userRepository.findById(managerId)
+                    .orElseThrow(() -> new NotFoundException("매니저를 찾을 수 없습니다."));
+
+            Matching newMatching = Matching.builder()
+                    .reservation(reservation)
+                    .manager(manager)
+                    .matchingPriority(newPriority++)
+                    .matchingIsRequest(false)
+                    .matchingUpdatedAt(LocalDateTime.now())
+                    .build();
+
+            matchingRepository.save(newMatching);
+            log.info("➕ 새로운 매칭 후보 추가: managerId={}, priority={}", managerId, newMatching.getMatchingPriority());
+        }
+
+        // 첫 번째 후보에게 즉시 요청
+        matchingRepository.findTopByReservation_ReservationIdAndMatchingPriorityGreaterThanOrderByMatchingPriorityAsc(
+                        reservationId, currentPriority)
+                .ifPresent(first -> {
+                    first.setMatchingIsRequest(true);
+                    first.setMatchingUpdatedAt(LocalDateTime.now());
+
+                    alertService.sendAlert(AlertRequestDto.builder()
+                            .userId(first.getManager().getUserId())
+                            .alertContent("매칭 요청이 왔어요.")
+                            .alertTrigger("Matching")
+                            .build());
+
+                    log.info("➡️ 재추천된 첫 매니저에게 요청 전송: reservationId={}, managerId={}", reservationId, first.getManager().getUserId());
+                });
     }
 
     // 매니저 매칭 답장
@@ -202,8 +214,10 @@ public class MatchingService {
     public void customerResponseMatching(Long matchingId, MatchingResponseRequestDto requestDto) {
         Matching matching = matchingRepository.findById(matchingId)
                 .orElseThrow(() -> new NotFoundException("매칭 정보를 찾을 수 없습니다."));
+
         if (matching.getMatchingIsFinal() != null) {
-            throw new IllegalStateException("이미 응답한 매칭입니다.");}
+            throw new IllegalStateException("이미 응답한 매칭입니다.");
+        }
 
         // 매니저가 거절했으면 수요자 수락 불가
         if (Boolean.FALSE.equals(matching.getMatchingManagerIsAccept())) {
@@ -216,82 +230,53 @@ public class MatchingService {
             triggerNextMatching(matching);
             return;
         }
+
         matching.setMatchingIsFinal(requestDto.getMatchingIsFinal());
-        if (requestDto.getMatchingRefuseReason() != null) {
-            matching.setMatchingRefuseReason(requestDto.getMatchingRefuseReason());}
-        Reservation reservation = matching.getReservation();
+        matching.setMatchingUpdatedAt(LocalDateTime.now());
 
-        // 매칭 수락 시
-        if (Boolean.TRUE.equals(matching.getMatchingIsFinal())) {
-            reservation.setReservationStatus(ReservationStatus.MATCHING);
-            reservation.setManager(matching.getManager());
-            reservation.setMatchedAt(LocalDateTime.now());
-
-            // 다른 매니저들에게 이미 매칭되었다고 알림
-            List<Matching> otherMatchings = matchingRepository
-                    .findAllByReservation_ReservationId(reservation.getReservationId());
-
-            for (Matching m : otherMatchings) {
-                if (!m.getMatchingId().equals(matchingId) && Boolean.TRUE.equals(m.getMatchingIsRequest())) {
-                    alertService.sendAlert(AlertRequestDto.builder()
-                            .userId(m.getManager().getUserId())
-                            .alertContent("다른 매니저와 매칭이 완료되었습니다.")
-                            .alertTrigger("Matching")
-                            .build());
-                }
+        if (!requestDto.getMatchingIsFinal()) {
+            if (requestDto.getMatchingRefuseReason() != null) {
+                matching.setMatchingRefuseReason(requestDto.getMatchingRefuseReason());
             }
-        } else {
-            // 마지막 매니저인지 판별
+
+            Reservation reservation = matching.getReservation();
             boolean isLastPriority = matchingRepository
                     .findTopByReservation_ReservationIdAndMatchingPriorityGreaterThanOrderByMatchingPriorityAsc(
                             reservation.getReservationId(), matching.getMatchingPriority()
                     )
                     .isEmpty();
+
             matching.setMatchingIsFinal(false);
-            matching.setMatchingUpdatedAt(LocalDateTime.now());
 
             if (isLastPriority) {
                 log.info("♻️ 마지막 매니저 수요자 거절 → 재매칭 실행: reservationId={}", reservation.getReservationId());
-                triggerNextMatching(matching); // 새로운 추천 3인 매칭 생성
+                triggerNextMatching(matching);
             } else {
-                log.info("⏭ 수요자 거절 → 다음 순위 매니저 요청은 스케줄러에 위임");
-                // 아무 처리 안 해도 다음 매니저는 스케줄러가 1분 뒤에 처리
+                log.info("⏭ 수요자 거절 → 다음 순위 매니저에게 바로 요청: reservationId={}", reservation.getReservationId());
+                triggerNextMatching(matching);
+            }
+            return;
+        }
+
+        // 수락 시
+        Reservation reservation = matching.getReservation();
+        reservation.setReservationStatus(ReservationStatus.MATCHING);
+        reservation.setManager(matching.getManager());
+        reservation.setMatchedAt(LocalDateTime.now());
+
+        List<Matching> otherMatchings = matchingRepository
+                .findAllByReservation_ReservationId(reservation.getReservationId());
+
+        for (Matching m : otherMatchings) {
+            if (!m.getMatchingId().equals(matchingId) && Boolean.TRUE.equals(m.getMatchingIsRequest())) {
+                alertService.sendAlert(AlertRequestDto.builder()
+                        .userId(m.getManager().getUserId())
+                        .alertContent("다른 매니저와 매칭이 완료되었습니다.")
+                        .alertTrigger("Matching")
+                        .build());
             }
         }
     }
-
-//    // 매칭거절
-//    @Transactional
-//    public void cancelMatching(Long matchingId, MatchingCancelRequestDto requestDto) {
-//        if (requestDto.getIsContinue()) {
-//            triggerNextMatching(matchingRepository.findById(matchingId).get());
-//        } else {
-//            Reservation reservation = matchingRepository.findById(matchingId).get().getReservation();
-//            reservation.setReservationStatus(ReservationStatus.CANCEL);
-//            reservation.setReservationCancelReason(requestDto.getCancelReason());
-//
-//            // 취소된 예약에 대해 매니저들에게 예약 취소 알람
-//            List<Matching> requestedMatching = matchingRepository
-//                    .findAllByReservation_ReservationId(reservation.getReservationId());
-//
-//            for (Matching m : requestedMatching) {
-//                if (m.getMatchingId() != matchingId) {
-//                    // m.setMatchingIsFinal(false);
-//                    // m.setMatchingRefuseReason("취소된 예약");
-//                    // m.setMatchingUpdatedAt(LocalDateTime.now());
-//                    if (m.getMatchingIsRequest()) {
-//                        if (m.getMatchingManagerIsAccept() || m.getMatchingManagerIsAccept() == null) {
-//                            alertService.sendAlert(AlertRequestDto.builder()
-//                                    .userId(m.getManager().getUserId())
-//                                    .alertContent("고객이 취소한 예약입니다.")
-//                                    .alertTrigger("Matching")
-//                                    .build());
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//    }
 
     // 매칭 신청 가능한 매니저 리스트 조회 (시간)
     @Transactional(readOnly = true)
@@ -396,7 +381,7 @@ public class MatchingService {
 
         double lat = address.getCustomerLatitude();
         double lng = address.getCustomerLongitude();
-        double rangeKm = 10.0;
+        double rangeKm = 20.0;
 
         Map<Long, User> userMap = managers.stream().collect(Collectors.toMap(User::getUserId, Function.identity()));
         List<ManagerDetail> managerDetails = managerDetailRepository.findByUserIdIn(userMap.keySet().stream().toList());


### PR DESCRIPTION
### 주요 변경 사항
스케줄러 방식 주석 처리
→ 무한 요청이 오는 오류가 생겨서 우선 주석처리했습니다. 추후에 리팩할게용

서비스 내부 로직으로 즉시 처리 전환
→ 매니저 또는 수요자가 매칭을 거절할 경우
→ triggerNextMatching() 즉시 실행하여 다음 매니저에게 매칭 요청 전송

최대 3명 추천 후 요청 실패 시, 자동 매칭 후보 추천 후 바로 요청