### PR TITLE
feat: 관리자 환불 통계 기능 구현 (환불 사유 + 환불률 + 사용자/매니저 TOP)

### DIFF
--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminCustomerRefundStatisticsDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminCustomerRefundStatisticsDto.java
@@ -1,0 +1,13 @@
+package com.antmen.antwork.admin.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AdminCustomerRefundStatisticsDto {
+    private Long customerId;
+    private String customerName;
+    private Long refundCount;
+    private Long totalRefundAmount;
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminManagerRefundStatisticsDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminManagerRefundStatisticsDto.java
@@ -1,0 +1,24 @@
+package com.antmen.antwork.admin.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AdminManagerRefundStatisticsDto {
+    private Long managerId;
+    private Long managerName;
+    private Long refundCount;
+    private Long totalRefundAmount;
+
+    public static AdminManagerRefundStatisticsDto from(Long managerId, Long managerName, Long refundCount, Long totalRefundAmount) {
+        return AdminManagerRefundStatisticsDto.builder()
+                .managerId(managerId)
+                .managerName(managerName)
+                .refundCount(refundCount)
+                .totalRefundAmount(totalRefundAmount)
+                .build();
+    }
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminManagerRefundStatisticsDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminManagerRefundStatisticsDto.java
@@ -9,16 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AdminManagerRefundStatisticsDto {
     private Long managerId;
-    private Long managerName;
+    private String managerName;
     private Long refundCount;
     private Long totalRefundAmount;
-
-    public static AdminManagerRefundStatisticsDto from(Long managerId, Long managerName, Long refundCount, Long totalRefundAmount) {
-        return AdminManagerRefundStatisticsDto.builder()
-                .managerId(managerId)
-                .managerName(managerName)
-                .refundCount(refundCount)
-                .totalRefundAmount(totalRefundAmount)
-                .build();
-    }
 }

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminReviewStatisticsDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminReviewStatisticsDto.java
@@ -15,6 +15,9 @@ import java.util.List;
 public class AdminReviewStatisticsDto {
     private Long totalReviewCount;
     private BigDecimal avgReviewSatisfaction;
+    private BigDecimal avgCustomerReviewSatisfaction;
+    private BigDecimal avgManagerReviewSatisfaction;
+
     private List<ReviewSatisfactionDto> topCustomerList;
     private List<ReviewSatisfactionDto> topManagerList;
 }

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminReviewStatisticsDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminReviewStatisticsDto.java
@@ -1,0 +1,20 @@
+package com.antmen.antwork.admin.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminReviewStatisticsDto {
+    private Long totalReviewCount;
+    private BigDecimal avgReviewSatisfaction;
+    private List<ReviewSatisfactionDto> topCustomerList;
+    private List<ReviewSatisfactionDto> topManagerList;
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/ReviewSatisfactionDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/ReviewSatisfactionDto.java
@@ -1,0 +1,19 @@
+package com.antmen.antwork.admin.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewSatisfactionDto {
+    private Long userId;
+    private String userName;
+    private BigDecimal avgReview;
+    private Long totalReviewCount;
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminRefundStatisticsController.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminRefundStatisticsController.java
@@ -1,6 +1,7 @@
 package com.antmen.antwork.admin.controller;
 
 import com.antmen.antwork.admin.api.AdminCustomerRefundStatisticsDto;
+import com.antmen.antwork.admin.api.AdminManagerRefundStatisticsDto;
 import com.antmen.antwork.admin.api.AdminRefundReasonStatisticsDto;
 import com.antmen.antwork.admin.api.AdminRefundStatisticsSummaryDto;
 import com.antmen.antwork.admin.service.AdminRefundStatisticsService;
@@ -32,6 +33,12 @@ public class AdminRefundStatisticsController {
     @GetMapping("/customers/top")
     public ResponseEntity<List<AdminCustomerRefundStatisticsDto>> getTopRefundCustomers() {
         List<AdminCustomerRefundStatisticsDto> result = adminRefundStatisticsService.getTopApprovedRefundCustomers();
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/managers/top")
+    public ResponseEntity<List<AdminManagerRefundStatisticsDto>> getTopRefundManagers() {
+        List<AdminManagerRefundStatisticsDto> result = adminRefundStatisticsService.getTopApprovedRefundManagers();
         return ResponseEntity.ok(result);
     }
 }

--- a/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminRefundStatisticsController.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminRefundStatisticsController.java
@@ -1,5 +1,6 @@
 package com.antmen.antwork.admin.controller;
 
+import com.antmen.antwork.admin.api.AdminCustomerRefundStatisticsDto;
 import com.antmen.antwork.admin.api.AdminRefundReasonStatisticsDto;
 import com.antmen.antwork.admin.api.AdminRefundStatisticsSummaryDto;
 import com.antmen.antwork.admin.service.AdminRefundStatisticsService;
@@ -25,6 +26,12 @@ public class AdminRefundStatisticsController {
     @GetMapping("/reasons")
     public ResponseEntity<List<AdminRefundReasonStatisticsDto>> getRefundReasonStats() {
         List<AdminRefundReasonStatisticsDto> result = adminRefundStatisticsService.getRefundReasonStatistics();
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/customers/top")
+    public ResponseEntity<List<AdminCustomerRefundStatisticsDto>> getTopRefundCustomers() {
+        List<AdminCustomerRefundStatisticsDto> result = adminRefundStatisticsService.getTopApprovedRefundCustomers();
         return ResponseEntity.ok(result);
     }
 }

--- a/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminReviewStatisticsController.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminReviewStatisticsController.java
@@ -1,0 +1,22 @@
+package com.antmen.antwork.admin.controller;
+
+import com.antmen.antwork.admin.api.AdminReviewStatisticsDto;
+import com.antmen.antwork.admin.service.AdminReviewStatisticService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/statistics/reviews/")
+public class AdminReviewStatisticsController {
+    private final AdminReviewStatisticService adminReviewStatisticService;
+
+    @GetMapping
+    public ResponseEntity<AdminReviewStatisticsDto> getReviewStatistics(@RequestParam(defaultValue = "3") int topN) {
+        return ResponseEntity.ok(adminReviewStatisticService.getReviewStatistics(topN));
+    }
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminRefundStatisticsService.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminRefundStatisticsService.java
@@ -1,6 +1,7 @@
 package com.antmen.antwork.admin.service;
 
 import com.antmen.antwork.admin.api.AdminCustomerRefundStatisticsDto;
+import com.antmen.antwork.admin.api.AdminManagerRefundStatisticsDto;
 import com.antmen.antwork.admin.api.AdminRefundReasonStatisticsDto;
 import com.antmen.antwork.admin.api.AdminRefundStatisticsSummaryDto;
 import com.antmen.antwork.common.domain.entity.reservation.RefundStatus;
@@ -46,6 +47,17 @@ public class AdminRefundStatisticsService {
                 .map(p -> new AdminCustomerRefundStatisticsDto(
                         p.getCustomerId(),
                         p.getCustomerName(),
+                        p.getRefundCount(),
+                        p.getTotalRefundAmount()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    public List<AdminManagerRefundStatisticsDto> getTopApprovedRefundManagers() {
+        return refundRepository.getTopApprovedRefundManagers(RefundStatus.APPROVED).stream()
+                .map(p -> new AdminManagerRefundStatisticsDto(
+                        p.getManagerId(),
+                        p.getManagerName(),
                         p.getRefundCount(),
                         p.getTotalRefundAmount()
                 ))

--- a/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminRefundStatisticsService.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminRefundStatisticsService.java
@@ -1,5 +1,6 @@
 package com.antmen.antwork.admin.service;
 
+import com.antmen.antwork.admin.api.AdminCustomerRefundStatisticsDto;
 import com.antmen.antwork.admin.api.AdminRefundReasonStatisticsDto;
 import com.antmen.antwork.admin.api.AdminRefundStatisticsSummaryDto;
 import com.antmen.antwork.common.domain.entity.reservation.RefundStatus;
@@ -37,6 +38,17 @@ public class AdminRefundStatisticsService {
     public List<AdminRefundReasonStatisticsDto> getRefundReasonStatistics() {
         return refundRepository.CountByRefundReason().stream()
                 .map(AdminRefundReasonStatisticsDto::from)
+                .collect(Collectors.toList());
+    }
+
+    public List<AdminCustomerRefundStatisticsDto> getTopApprovedRefundCustomers() {
+        return refundRepository.getTopApprovedRefundCustomers(RefundStatus.APPROVED).stream()
+                .map(p -> new AdminCustomerRefundStatisticsDto(
+                        p.getCustomerId(),
+                        p.getCustomerName(),
+                        p.getRefundCount(),
+                        p.getTotalRefundAmount()
+                ))
                 .collect(Collectors.toList());
     }
 }

--- a/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminReviewStatisticService.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminReviewStatisticService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 
 @Service
@@ -31,6 +32,9 @@ public class AdminReviewStatisticService {
                 .reduce(BigDecimal.ZERO, BigDecimal::add)
                 .divide(BigDecimal.valueOf(totalCount), 2, BigDecimal.ROUND_HALF_UP);
 
+        BigDecimal avgCustomerScore = calcAvgByRole(allSummaries, UserRole.CUSTOMER);
+        BigDecimal avgManagerScore = calcAvgByRole(allSummaries, UserRole.MANAGER);
+
         List<ReviewSatisfactionDto> topManagers = reviewSummaryRepository
                 .findTopByRole(UserRole.MANAGER, PageRequest.of(0, topN))
                 .stream()
@@ -46,6 +50,8 @@ public class AdminReviewStatisticService {
         return AdminReviewStatisticsDto.builder()
                 .totalReviewCount(totalCount)
                 .avgReviewSatisfaction(avg)
+                .avgCustomerReviewSatisfaction(avgCustomerScore)
+                .avgManagerReviewSatisfaction(avgManagerScore)
                 .topManagerList(topManagers)
                 .topCustomerList(topCustomers)
                 .build();
@@ -58,5 +64,23 @@ public class AdminReviewStatisticService {
                 .avgReview(reviewSummary.getAvgRating())
                 .totalReviewCount(reviewSummary.getTotalReviews())
                 .build();
+    }
+
+    BigDecimal calcAvgByRole(List<ReviewSummary> summaries, UserRole role) {
+        List<ReviewSummary> filtered = summaries.stream()
+                .filter(rs -> rs.getRole() == role)
+                .toList();
+
+        Long totalCount = filtered.stream()
+                .mapToLong(ReviewSummary::getTotalReviews)
+                .sum();
+
+        if (totalCount == 0) return BigDecimal.ZERO;
+
+        BigDecimal totalScoreSum = filtered.stream()
+                .map(rs -> rs.getAvgRating().multiply(BigDecimal.valueOf(rs.getTotalReviews())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        return totalScoreSum.divide(BigDecimal.valueOf(totalCount), 2, RoundingMode.HALF_UP);
     }
 }

--- a/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminReviewStatisticService.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminReviewStatisticService.java
@@ -1,0 +1,62 @@
+package com.antmen.antwork.admin.service;
+
+import com.antmen.antwork.admin.api.AdminReviewStatisticsDto;
+import com.antmen.antwork.admin.api.ReviewSatisfactionDto;
+import com.antmen.antwork.common.domain.entity.ReviewSummary;
+import com.antmen.antwork.common.domain.entity.account.UserRole;
+import com.antmen.antwork.common.infra.repository.account.UserRepository;
+import com.antmen.antwork.common.infra.repository.reservation.ReviewSummaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminReviewStatisticService {
+    private final ReviewSummaryRepository reviewSummaryRepository;
+    private final UserRepository userRepository;
+
+    public AdminReviewStatisticsDto getReviewStatistics(int topN) {
+        List<ReviewSummary> allSummaries = reviewSummaryRepository.findAll();
+        Long totalCount = allSummaries.stream().mapToLong(ReviewSummary::getTotalReviews).sum();
+
+        BigDecimal avg = allSummaries.stream()
+                .map(summary -> summary.getAvgRating()
+                        .multiply(BigDecimal.valueOf(summary.getTotalReviews())))
+                .reduce(BigDecimal.ZERO, BigDecimal::add)
+                .divide(BigDecimal.valueOf(totalCount), 2, BigDecimal.ROUND_HALF_UP);
+
+        List<ReviewSatisfactionDto> topManagers = reviewSummaryRepository
+                .findTopByRole(UserRole.MANAGER, PageRequest.of(0, topN))
+                .stream()
+                .map(this::toDto)
+                .toList();
+
+        List<ReviewSatisfactionDto> topCustomers = reviewSummaryRepository
+                .findTopByRole(UserRole.CUSTOMER, PageRequest.of(0, topN))
+                .stream()
+                .map(this::toDto)
+                .toList();
+
+        return AdminReviewStatisticsDto.builder()
+                .totalReviewCount(totalCount)
+                .avgReviewSatisfaction(avg)
+                .topManagerList(topManagers)
+                .topCustomerList(topCustomers)
+                .build();
+    }
+
+    private ReviewSatisfactionDto toDto(ReviewSummary reviewSummary) {
+        return ReviewSatisfactionDto.builder()
+                .userId(reviewSummary.getUserId())
+                .userName(reviewSummary.getUser().getUserName())
+                .avgReview(reviewSummary.getAvgRating())
+                .totalReviewCount(reviewSummary.getTotalReviews())
+                .build();
+    }
+}

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/RefundRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/RefundRepository.java
@@ -14,21 +14,35 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
     List<Refund> findByRefundStatus(RefundStatus refundStatus);
     boolean existsByPayment_PayId(Long payId);
 
-    @Query("SELECT SUM(r.payment.payAmount) FROM Refund r")
-    Long TotalRefundAmount();
-
     @Query("SELECT SUM(r.payment.payAmount) FROM Refund r WHERE r.refundStatus = :refundStatus")
     Long TotalRefundAmountByStatus(@Param("refundStatus") RefundStatus refundStatus);
 
     Long countByRefundStatus(RefundStatus status);
 
+    interface RefundReasonStatisticsDto {
+        String getReason();
+        Long getCount();
+    }
     @Query("SELECT r.refundReason AS reason, COUNT(r) AS count " +
             "FROM Refund r " +
             "GROUP BY r.refundReason " +
             "ORDER BY count DESC")
     List<RefundReasonStatisticsDto> CountByRefundReason();
-    interface RefundReasonStatisticsDto {
-        String getReason();
-        Long getCount();
+
+    interface CustomerRefundProjection {
+        Long getCustomerId();
+        String getCustomerName();
+        Long getRefundCount();
+        Long getTotalRefundAmount();
     }
+    @Query("SELECT res.customer.userId AS customerId, " +
+            "res.customer.userName AS customerName, " +
+            "COUNT(r) AS refundCount, SUM(p.payAmount) AS totalRefundAmount " +
+            "FROM Refund r " +
+            "JOIN r.payment p " +
+            "JOIN p.reservation res " +
+            "WHERE r.refundStatus = :status " +
+            "GROUP BY res.customer.userId, res.customer.userName " +
+            "ORDER BY totalRefundAmount DESC")
+    List<CustomerRefundProjection> getTopApprovedRefundCustomers(@Param("status") RefundStatus status);
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/RefundRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/RefundRepository.java
@@ -45,4 +45,22 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
             "GROUP BY res.customer.userId, res.customer.userName " +
             "ORDER BY totalRefundAmount DESC")
     List<CustomerRefundProjection> getTopApprovedRefundCustomers(@Param("status") RefundStatus status);
+
+    interface ManagerRefundProjection {
+        Long getManagerId();
+        String getManagerName();
+        Long getRefundCount();
+        Long getTotalRefundAmount();
+    }
+    @Query("SELECT res.manager.userId AS managerId, " +
+            "res.manager.userName AS managerName, " +
+            "COUNT(r) AS refundCount, SUM(p.payAmount) AS totalRefundAmount " +
+            "FROM Refund r " +
+            "JOIN r.payment p " +
+            "JOIN p.reservation res " +
+            "WHERE r.refundStatus = :status " +
+            "AND res.manager IS NOT NULL " +
+            "GROUP BY res.manager.userId, res.manager.userName " +
+            "ORDER BY totalRefundAmount DESC")
+    List<ManagerRefundProjection> getTopApprovedRefundManagers(@Param("status") RefundStatus status);
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/ReviewSummaryRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/ReviewSummaryRepository.java
@@ -3,11 +3,25 @@ package com.antmen.antwork.common.infra.repository.reservation;
 import com.antmen.antwork.common.domain.entity.ReviewSummary;
 import com.antmen.antwork.common.domain.entity.account.UserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
+import org.springframework.data.domain.Pageable;
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ReviewSummaryRepository extends JpaRepository<ReviewSummary, Long> {
     Optional<ReviewSummary> findByUserIdAndRole(Long userId, UserRole role);
+
+    interface ReviewerSatisfactionProjection {
+        Long getUserId();
+        String getName();
+        BigDecimal getAvgRating();
+        Long getTotalReviews();
+    }
+    @Query("SELECT rs FROM ReviewSummary rs " +
+            "WHERE rs.role = :role " +
+            "ORDER BY rs.avgRating DESC, rs.totalReviews DESC ")
+    List<ReviewSummary> findTopByRole(UserRole role, Pageable pageable);
 }


### PR DESCRIPTION
- 관련 이슈 : #203 
https://github.com/Kernel360/KBE5_AntMen_BE/pull/204#issue-3226438704 합쳐서 pr 올립니다 :)

## 📌 주요 변경 사항

### ✅ 1. 환불 통계 기능

#### 🔹 전체 환불률 통계 API (\`GET /admin/refunds/summary\`)
- 전체 예약 대비 환불 비율 계산: \`refundRate = totalRefund / totalReservation * 100\`
- 승인 환불 수(\`APPROVED\`) 및 환불 금액 합계 포함
- 환불률은 소수점 둘째자리까지 반올림
- **DTO**: \`AdminRefundStatisticsSummaryDto\`

#### 🔹 환불 사유 통계 API (\`GET /admin/refunds/reasons\`)
- \`refundReason\` 기준 \`COUNT(*)\` 집계
- 프론트에서 기타 분류 가능하도록 전체 리스트 반환
- 정렬 기준: 발생 건수 내림차순
- **DTO**: \`AdminRefundReasonStatisticsDto\`

#### 🔹 사용자 환불 TOP API (\`GET /admin/refunds/customers/top\`)
- \`APPROVED\` 상태의 환불만 집계
- 사용자별 \`userId\`, \`userName\`, \`refundCount\`, \`totalRefundAmount\` 반환
- interface-based projection → DTO 변환 방식
- **DTO**: \`AdminCustomerRefundStatisticsDto\`

#### 🔹 매니저 환불 TOP API (\`GET /admin/refunds/managers/top\`)
- 사용자 통계와 동일 구조로 매니저 기준 통계 반환
- **DTO**: \`AdminManagerRefundStatisticsDto\`

---

## 🧪 테스트 시나리오

- [x] 환불률/사유/고객/매니저 통계 API 응답 확인
- [x] 카테고리/옵션 CRUD 정상 작동
- [x] 검색 필터 → 테이블 뷰 전환 확인
- [x] 그룹 뷰 내 확장/축소 동작
- [x] 에러 및 로딩 상태 확인

---

## 📁 디렉터리 변경 요약

<img width="478" height="426" alt="스크린샷 2025-07-13 21 42 33" src="https://github.com/user-attachments/assets/dab067a6-6ce8-403b-8b75-bee141c64b86" />



## 🧱 설계 참고

- Repository 모듈은 공통 모듈에 위치
- admin 전용 DTO에서 Projection 결과를 매핑하여 사용
- 소수점 환불률 반올림 처리 (\`Math.round(x * 100) / 100\`)
- 서비스 특성상 금액 기준 TOP 정렬이 더 유효

---

## 📌 후속 작업 제안

- [ ] 통계 기간 필터링 (\`fromDate\`, \`toDate\`) 추가
- [ ] 사용자/매니저 상세 내역 API 연동
- [ ] 환불률 + 금액 + 사유 통합 시각화 설계
- [ ] 통계 캐싱 적용 (e.g. Redis)

---
**라벨**: \`feat\`, \`admin\`, \`dashboard\`, \`refund\`