### PR TITLE
feat: 관리자 통계 - 매칭률

### DIFF
--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminMatchingStatisticsSummaryDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminMatchingStatisticsSummaryDto.java
@@ -1,0 +1,17 @@
+package com.antmen.antwork.admin.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminMatchingStatisticsSummaryDto {
+    private MatchingSummaryResponseDto matchingSummary;
+    private List<MatchingTopManagerDto> topManagerList;
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminMatchingStatisticsSummaryDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminMatchingStatisticsSummaryDto.java
@@ -14,4 +14,5 @@ import java.util.List;
 public class AdminMatchingStatisticsSummaryDto {
     private MatchingSummaryResponseDto matchingSummary;
     private List<MatchingTopManagerDto> topManagerList;
+    private List<DailyMatchingResponseDto> dailyMatchingList;
 }

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminReviewStatisticsDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/AdminReviewStatisticsDto.java
@@ -20,4 +20,6 @@ public class AdminReviewStatisticsDto {
 
     private List<ReviewSatisfactionDto> topCustomerList;
     private List<ReviewSatisfactionDto> topManagerList;
+    private List<ReviewSatisfactionDto> topCustomerByReviewCount;
+    private List<ReviewSatisfactionDto> topManagerByReviewCount;
 }

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/DailyMatchingResponseDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/DailyMatchingResponseDto.java
@@ -1,0 +1,20 @@
+package com.antmen.antwork.admin.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DailyMatchingResponseDto {
+    private LocalDate date;
+    private Long requestCount;
+    private Long successCount;
+    private BigDecimal matchingRate;
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/MatchingSummaryResponseDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/MatchingSummaryResponseDto.java
@@ -1,0 +1,19 @@
+package com.antmen.antwork.admin.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MatchingSummaryResponseDto {
+    private BigDecimal matchingRating;
+    private Long totalMatchingCount;
+    private Long successCount;
+    private Long failCount;
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/MatchingSummaryResponseDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/MatchingSummaryResponseDto.java
@@ -16,4 +16,7 @@ public class MatchingSummaryResponseDto {
     private Long totalMatchingCount;
     private Long successCount;
     private Long failCount;
+
+    private BigDecimal customerRefuseRate;
+    private BigDecimal managerRefuseRate;
 }

--- a/m-admin/src/main/java/com/antmen/antwork/admin/api/MatchingTopManagerDto.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/api/MatchingTopManagerDto.java
@@ -1,0 +1,16 @@
+package com.antmen.antwork.admin.api;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MatchingTopManagerDto {
+    private Long managerId;
+    private String managerName;
+    private Long successCount;
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminMatchingStatisticsController.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminMatchingStatisticsController.java
@@ -1,0 +1,21 @@
+package com.antmen.antwork.admin.controller;
+
+import com.antmen.antwork.admin.api.AdminMatchingStatisticsSummaryDto;
+import com.antmen.antwork.admin.service.AdminMatchingStatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/statistics/matchings")
+public class AdminMatchingStatisticsController {
+    private final AdminMatchingStatisticsService adminMatchingStatisticsService;
+
+    @GetMapping
+    public ResponseEntity<AdminMatchingStatisticsSummaryDto> getMatchingStatistics(){
+        return ResponseEntity.ok(adminMatchingStatisticsService.getMatchingStatisticsSummaryDto());
+    }
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminReviewStatisticsController.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/controller/AdminReviewStatisticsController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/admin/statistics/reviews/")
+@RequestMapping("/api/v1/admin/statistics/reviews")
 public class AdminReviewStatisticsController {
     private final AdminReviewStatisticService adminReviewStatisticService;
 

--- a/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminMatchingStatisticsService.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminMatchingStatisticsService.java
@@ -24,12 +24,27 @@ public class AdminMatchingStatisticsService {
 
     public AdminMatchingStatisticsSummaryDto getMatchingStatisticsSummaryDto() {
         long total = matchingRepository.count();
-        Long success = matchingRepository.countByMatchingIsFinalTrue();
+        Long success = matchingRepository.countSuccess();
         Long fail = total - success;
 
         BigDecimal matchingRate = total == 0
                 ? BigDecimal.ZERO
                 : BigDecimal.valueOf(success)
+                .divide(BigDecimal.valueOf(total), 2, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100));
+
+        Long customerRefuse = matchingRepository.countRefusedByCustomer();
+        Long managerRefuse = matchingRepository.countRefusedByManager();
+
+        BigDecimal customerRefuseRate = (total == 0)
+                ? BigDecimal.ZERO
+                : BigDecimal.valueOf(customerRefuse)
+                .divide(BigDecimal.valueOf(total), 2, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100));
+
+        BigDecimal managerRefuseRate = (total == 0)
+                ? BigDecimal.ZERO
+                : BigDecimal.valueOf(managerRefuse)
                 .divide(BigDecimal.valueOf(total), 2, RoundingMode.HALF_UP)
                 .multiply(BigDecimal.valueOf(100));
 
@@ -61,6 +76,8 @@ public class AdminMatchingStatisticsService {
                 .totalMatchingCount(total)
                 .successCount(success)
                 .failCount(fail)
+                .customerRefuseRate(customerRefuseRate)
+                .managerRefuseRate(managerRefuseRate)
                 .build();
 
         return AdminMatchingStatisticsSummaryDto.builder()

--- a/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminMatchingStatisticsService.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminMatchingStatisticsService.java
@@ -1,6 +1,7 @@
 package com.antmen.antwork.admin.service;
 
 import com.antmen.antwork.admin.api.AdminMatchingStatisticsSummaryDto;
+import com.antmen.antwork.admin.api.DailyMatchingResponseDto;
 import com.antmen.antwork.admin.api.MatchingSummaryResponseDto;
 import com.antmen.antwork.admin.api.MatchingTopManagerDto;
 import com.antmen.antwork.common.infra.repository.reservation.MatchingRepository;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -38,6 +40,22 @@ public class AdminMatchingStatisticsService {
                         .successCount(p.getSuccessCount())
                         .build()).toList();
 
+        LocalDate today = LocalDate.now();
+        LocalDate startDate = today.minusDays(6);
+        List<DailyMatchingResponseDto> dailyList = matchingRepository.findDailyMatchingStats(
+                startDate.atStartOfDay(), today.atTime(23,59,59)).stream()
+                .map(p-> {
+            BigDecimal rate = p.getRequestCount() == 0 ? BigDecimal.ZERO :
+                    BigDecimal.valueOf(p.getSuccessCount())
+                            .divide(BigDecimal.valueOf(p.getRequestCount()), 2, RoundingMode.HALF_UP)
+                            .multiply(BigDecimal.valueOf(100));
+            return DailyMatchingResponseDto.builder()
+                    .date(p.getDate())
+                    .requestCount(p.getRequestCount())
+                    .successCount(p.getSuccessCount())
+                    .matchingRate(rate).build();
+        }).toList();
+
         MatchingSummaryResponseDto summary = MatchingSummaryResponseDto.builder()
                 .matchingRating(matchingRate)
                 .totalMatchingCount(total)
@@ -48,6 +66,7 @@ public class AdminMatchingStatisticsService {
         return AdminMatchingStatisticsSummaryDto.builder()
                 .matchingSummary(summary)
                 .topManagerList(topManagers)
+                .dailyMatchingList(dailyList)
                 .build();
     }
 }

--- a/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminMatchingStatisticsService.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminMatchingStatisticsService.java
@@ -1,0 +1,53 @@
+package com.antmen.antwork.admin.service;
+
+import com.antmen.antwork.admin.api.AdminMatchingStatisticsSummaryDto;
+import com.antmen.antwork.admin.api.MatchingSummaryResponseDto;
+import com.antmen.antwork.admin.api.MatchingTopManagerDto;
+import com.antmen.antwork.common.infra.repository.reservation.MatchingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminMatchingStatisticsService {
+    private final MatchingRepository matchingRepository;
+
+    public AdminMatchingStatisticsSummaryDto getMatchingStatisticsSummaryDto() {
+        long total = matchingRepository.count();
+        Long success = matchingRepository.countByMatchingIsFinalTrue();
+        Long fail = total - success;
+
+        BigDecimal matchingRate = total == 0
+                ? BigDecimal.ZERO
+                : BigDecimal.valueOf(success)
+                .divide(BigDecimal.valueOf(total), 2, RoundingMode.HALF_UP)
+                .multiply(BigDecimal.valueOf(100));
+
+        List<MatchingTopManagerDto> topManagers = matchingRepository.findTopManagers(Pageable.ofSize(5)).stream()
+                .map(p-> MatchingTopManagerDto.builder()
+                        .managerId(p.getManagerId())
+                        .managerName(p.getManagerName())
+                        .successCount(p.getSuccessCount())
+                        .build()).toList();
+
+        MatchingSummaryResponseDto summary = MatchingSummaryResponseDto.builder()
+                .matchingRating(matchingRate)
+                .totalMatchingCount(total)
+                .successCount(success)
+                .failCount(fail)
+                .build();
+
+        return AdminMatchingStatisticsSummaryDto.builder()
+                .matchingSummary(summary)
+                .topManagerList(topManagers)
+                .build();
+    }
+}

--- a/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminReviewStatisticService.java
+++ b/m-admin/src/main/java/com/antmen/antwork/admin/service/AdminReviewStatisticService.java
@@ -20,50 +20,54 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class AdminReviewStatisticService {
     private final ReviewSummaryRepository reviewSummaryRepository;
-    private final UserRepository userRepository;
 
     public AdminReviewStatisticsDto getReviewStatistics(int topN) {
         List<ReviewSummary> allSummaries = reviewSummaryRepository.findAll();
-        Long totalCount = allSummaries.stream().mapToLong(ReviewSummary::getTotalReviews).sum();
+        long totalCount = allSummaries.stream().mapToLong(ReviewSummary::getTotalReviews).sum();
 
         BigDecimal avg = allSummaries.stream()
                 .map(summary -> summary.getAvgRating()
                         .multiply(BigDecimal.valueOf(summary.getTotalReviews())))
                 .reduce(BigDecimal.ZERO, BigDecimal::add)
-                .divide(BigDecimal.valueOf(totalCount), 2, BigDecimal.ROUND_HALF_UP);
+                .divide(BigDecimal.valueOf(totalCount), 2, RoundingMode.HALF_UP);
 
         BigDecimal avgCustomerScore = calcAvgByRole(allSummaries, UserRole.CUSTOMER);
         BigDecimal avgManagerScore = calcAvgByRole(allSummaries, UserRole.MANAGER);
 
-        List<ReviewSatisfactionDto> topManagers = reviewSummaryRepository
-                .findTopByRole(UserRole.MANAGER, PageRequest.of(0, topN))
-                .stream()
-                .map(this::toDto)
-                .toList();
+        // 평점 기준
+        List<ReviewSatisfactionDto> topManagersByRating = toDtoList(
+                reviewSummaryRepository.findTopByAvgRating(UserRole.MANAGER, PageRequest.of(0, topN)));
+        List<ReviewSatisfactionDto> topCustomersByRating = toDtoList(
+                reviewSummaryRepository.findTopByAvgRating(UserRole.CUSTOMER, PageRequest.of(0, topN)));
 
-        List<ReviewSatisfactionDto> topCustomers = reviewSummaryRepository
-                .findTopByRole(UserRole.CUSTOMER, PageRequest.of(0, topN))
-                .stream()
-                .map(this::toDto)
-                .toList();
+        // 개수 기준
+        List<ReviewSatisfactionDto> topManagersByCount = toDtoList(
+                reviewSummaryRepository.findTopByTotalReviews(UserRole.MANAGER, PageRequest.of(0, topN)));
+        List<ReviewSatisfactionDto> topCustomersByCount = toDtoList(
+                reviewSummaryRepository.findTopByTotalReviews(UserRole.CUSTOMER, PageRequest.of(0, topN)));
 
         return AdminReviewStatisticsDto.builder()
                 .totalReviewCount(totalCount)
                 .avgReviewSatisfaction(avg)
                 .avgCustomerReviewSatisfaction(avgCustomerScore)
                 .avgManagerReviewSatisfaction(avgManagerScore)
-                .topManagerList(topManagers)
-                .topCustomerList(topCustomers)
+
+                .topManagerList(topManagersByRating)
+                .topCustomerList(topCustomersByRating)
+                .topManagerByReviewCount(topManagersByCount)
+                .topCustomerByReviewCount(topCustomersByCount)
                 .build();
     }
 
-    private ReviewSatisfactionDto toDto(ReviewSummary reviewSummary) {
-        return ReviewSatisfactionDto.builder()
-                .userId(reviewSummary.getUserId())
-                .userName(reviewSummary.getUser().getUserName())
-                .avgReview(reviewSummary.getAvgRating())
-                .totalReviewCount(reviewSummary.getTotalReviews())
-                .build();
+    private List<ReviewSatisfactionDto> toDtoList(List<ReviewSummaryRepository.ReviewerSatisfactionProjection> projections) {
+        return projections.stream()
+                .map(p -> ReviewSatisfactionDto.builder()
+                        .userId(p.getUserId())
+                        .userName(p.getName())
+                        .avgReview(p.getAvgRating())
+                        .totalReviewCount(p.getTotalReviews())
+                        .build())
+                .toList();
     }
 
     BigDecimal calcAvgByRole(List<ReviewSummary> summaries, UserRole role) {
@@ -71,7 +75,7 @@ public class AdminReviewStatisticService {
                 .filter(rs -> rs.getRole() == role)
                 .toList();
 
-        Long totalCount = filtered.stream()
+        long totalCount = filtered.stream()
                 .mapToLong(ReviewSummary::getTotalReviews)
                 .sum();
 

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepository.java
@@ -62,7 +62,7 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
         Long getSuccessCount();
     }
     @Query("""
-    SELECT 
+    SELECT
         m.manager.userId AS managerId,
         m.manager.userName AS managerName,
         COUNT(m) AS successCount
@@ -74,15 +74,15 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
     List<MatchingTopManagerProjection> findTopManagers(Pageable pageable);
 
     @Query("SELECT COUNT(m) FROM Matching m WHERE m.matchingIsFinal = true")
-    Long countByMatchingIsFinalTrue();
+    Long countSuccess();
 
     interface DailyMatchingStatisticsProjection {
-        LocalDate getDate();           // 날짜 (예: 2025-07-10)
-        Long getRequestCount();        // 총 요청 수
-        Long getSuccessCount();        // 성공 수
+        LocalDate getDate();
+        Long getRequestCount();
+        Long getSuccessCount();
     }
     @Query("""
-    SELECT 
+    SELECT
         FUNCTION('DATE', m.matchingUpdatedAt) AS date,
         COUNT(m) AS requestCount,
         SUM(CASE WHEN m.matchingIsFinal = true THEN 1 ELSE 0 END) AS successCount
@@ -92,4 +92,23 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
     ORDER BY FUNCTION('DATE', m.matchingUpdatedAt)
     """)
     List<DailyMatchingStatisticsProjection> findDailyMatchingStats(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
+
+    @Query("""
+    SELECT COUNT(m)
+    FROM Matching m
+    WHERE m.matchingManagerIsAccept = true
+    AND (m.matchingIsFinal IS NULL OR m.matchingIsFinal = false)
+""")
+    Long countRefusedByCustomer();
+
+    @Query("""
+    SELECT COUNT(m)
+    FROM Matching m
+    WHERE m.matchingIsRequest = true
+    AND (m.matchingManagerIsAccept IS NULL OR m.matchingManagerIsAccept = false)
+""")
+    Long countRefusedByManager();
+
+    @Query("SELECT COUNT(m) FROM Matching m")
+    Long countAll();
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepository.java
@@ -3,6 +3,7 @@ package com.antmen.antwork.common.infra.repository.reservation;
 import com.antmen.antwork.common.domain.entity.account.User;
 import com.antmen.antwork.common.domain.entity.reservation.Matching;
 import com.antmen.antwork.common.domain.entity.reservation.Reservation;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -53,4 +54,30 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
                     ")"
     )
     long countTheResponse(Reservation reservation);
+
+//    @Query("SELECT COUNT(m) FROM Matching m ")
+//    Long countMatching();
+
+//    @Query("SELECT COUNT(m) FROM Matching m WHERE m.matchingIsFinal = true")
+//    Long countSuccess();
+
+    interface MatchingTopManagerProjection {
+        Long getManagerId();
+        String getManagerName();
+        Long getSuccessCount();
+    }
+    @Query("""
+    SELECT 
+        m.manager.userId AS managerId,
+        m.manager.userName AS managerName,
+        COUNT(m) AS successCount
+    FROM Matching m
+    WHERE m.matchingIsFinal = true
+    GROUP BY m.manager.userId, m.manager.userName
+    ORDER BY successCount DESC
+    """)
+    List<MatchingTopManagerProjection> findTopManagers(Pageable pageable);
+
+    @Query("SELECT COUNT(m) FROM Matching m WHERE m.matchingIsFinal = true")
+    Long countByMatchingIsFinalTrue();
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/MatchingRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -55,12 +56,6 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
     )
     long countTheResponse(Reservation reservation);
 
-//    @Query("SELECT COUNT(m) FROM Matching m ")
-//    Long countMatching();
-
-//    @Query("SELECT COUNT(m) FROM Matching m WHERE m.matchingIsFinal = true")
-//    Long countSuccess();
-
     interface MatchingTopManagerProjection {
         Long getManagerId();
         String getManagerName();
@@ -80,4 +75,21 @@ public interface MatchingRepository extends JpaRepository<Matching, Long>, Match
 
     @Query("SELECT COUNT(m) FROM Matching m WHERE m.matchingIsFinal = true")
     Long countByMatchingIsFinalTrue();
+
+    interface DailyMatchingStatisticsProjection {
+        LocalDate getDate();           // 날짜 (예: 2025-07-10)
+        Long getRequestCount();        // 총 요청 수
+        Long getSuccessCount();        // 성공 수
+    }
+    @Query("""
+    SELECT 
+        FUNCTION('DATE', m.matchingUpdatedAt) AS date,
+        COUNT(m) AS requestCount,
+        SUM(CASE WHEN m.matchingIsFinal = true THEN 1 ELSE 0 END) AS successCount
+    FROM Matching m
+    WHERE m.matchingUpdatedAt BETWEEN :start AND :end
+    GROUP BY FUNCTION('DATE', m.matchingUpdatedAt)
+    ORDER BY FUNCTION('DATE', m.matchingUpdatedAt)
+    """)
+    List<DailyMatchingStatisticsProjection> findDailyMatchingStats(@Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 }

--- a/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/ReviewSummaryRepository.java
+++ b/m-common/src/main/java/com/antmen/antwork/common/infra/repository/reservation/ReviewSummaryRepository.java
@@ -4,6 +4,7 @@ import com.antmen.antwork.common.domain.entity.ReviewSummary;
 import com.antmen.antwork.common.domain.entity.account.UserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.data.domain.Pageable;
 import java.math.BigDecimal;
@@ -20,8 +21,28 @@ public interface ReviewSummaryRepository extends JpaRepository<ReviewSummary, Lo
         BigDecimal getAvgRating();
         Long getTotalReviews();
     }
-    @Query("SELECT rs FROM ReviewSummary rs " +
-            "WHERE rs.role = :role " +
-            "ORDER BY rs.avgRating DESC, rs.totalReviews DESC ")
-    List<ReviewSummary> findTopByRole(UserRole role, Pageable pageable);
+    @Query("""
+        SELECT rs.userId AS userId,
+               u.userName AS name,
+               rs.avgRating AS avgRating,
+               rs.totalReviews AS totalReviews
+        FROM ReviewSummary rs
+        JOIN User u ON rs.userId = u.userId
+        WHERE rs.role = :role
+        ORDER BY rs.avgRating DESC, rs.totalReviews DESC
+    """)
+    List<ReviewerSatisfactionProjection> findTopByAvgRating(@Param("role") UserRole role, Pageable pageable);
+
+    // 2. 리뷰 개수 많은 순 Projection (Top N)
+    @Query("""
+        SELECT rs.userId AS userId,
+               u.userName AS name,
+               rs.avgRating AS avgRating,
+               rs.totalReviews AS totalReviews
+        FROM ReviewSummary rs
+        JOIN User u ON rs.userId = u.userId
+        WHERE rs.role = :role
+        ORDER BY rs.totalReviews DESC
+    """)
+    List<ReviewerSatisfactionProjection> findTopByTotalReviews(@Param("role") UserRole role, Pageable pageable);
 }


### PR DESCRIPTION
- #209 
## ✅ 주요 구현 내용
 
 ### 1. 📊 관리자 매칭 통계 API 종합 제공
- API: `GET /api/v1/admin/statistics/matching`
- 응답 구조: AdminMatchingStatisticsSummaryDto
 
### 2. 응답 DTO 구성
 #### a. MatchingSummaryResponseDto
 - matchingRating: 전체 매칭률 (%)
 - totalMatchingCount: 전체 매칭 시도 건수
 - successCount: 성공 건수
 - failCount: 실패 건수
 - customerRefuseRate: 수요자 거부율
 - managerRefuseRate: 매니저 거부율

 #### b. MatchingTopManagerDto[]
 - 매니저별 매칭 성공 건수 TOP 5 조회 (최근 순)

 #### c. DailyMatchingResponseDto[]
 - 최근 7일간 일별 매칭 요청/성공 건수 및 매칭률